### PR TITLE
Decrypt SSM params of type SecureString

### DIFF
--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -11,7 +11,7 @@ provider:
           burstLimit: 200
           rateLimit: 100
   environment:
-    CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password}
+    CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password~true}
     BUCKET_NAME: ${self:service}-${self:provider.stage}-bucket
   s3:
     documentsBucket:


### PR DESCRIPTION
I have converted our "secret" SSM params from type String to type SecureString, so that they are encrypted at rest.

We need to tell serverless to decrypt them before injecting them as environment variables, otherwise we will get the encrypted value.

It seems that terraform does this by default.
