### PR TITLE
DES-210: Process provided validity time

### DIFF
--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -17,13 +17,14 @@ namespace DocumentsApi.Tests.V1.E2ETests
         public async Task CanCreateClaimsWithValidParams()
         {
             var uri = new Uri($"api/v1/claims", UriKind.Relative);
-            var retentionExpiresAt = DateTime.UtcNow.AddDays(3);
-            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(retentionExpiresAt);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
+            var formattedValidUntil = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(4));
             string body = "{" +
                 "\"serviceAreaCreatedBy\": \"development-team-staging\"," +
                 "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
                 "\"apiCreatedBy\": \"evidence-api\"," +
-                $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}" +
+                $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
+                $"\"validUntil\": {formattedValidUntil}" +
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -36,7 +37,6 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var document = DatabaseContext.Documents.First();
 
             var formattedCreatedAt = JsonConvert.SerializeObject(created.CreatedAt);
-            var formattedValidUntil = JsonConvert.SerializeObject(created.ValidUntil);
             var formattedDocumentCreatedAt = JsonConvert.SerializeObject(document.CreatedAt);
             string expected = "{" +
                               $"\"id\":\"{created.Id}\"," +
@@ -137,6 +137,60 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
             var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
 
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
+        public async Task CanUpdateClaimWithValidParams()
+        {
+            // Arrange
+            var claim = TestDataHelper.CreateClaim().ToEntity();
+            DatabaseContext.Add(claim);
+            DatabaseContext.SaveChanges();
+
+            var validUntil = DateTime.UtcNow.AddDays(4);
+            var formattedValidUntil = JsonConvert.SerializeObject(validUntil);
+            string body = "{" +
+                          $"\"validUntil\": {formattedValidUntil}" +
+                          "}";
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/claims/{claim.Id}", UriKind.Relative);
+
+            // Act
+            var response = await Client.PatchAsync(uri, jsonString).ConfigureAwait(true);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var result = JsonConvert.DeserializeObject<ClaimResponse>(json);
+
+            result.Should().BeEquivalentTo(claim.ToDomain().ToResponse(),
+                opts => opts.Excluding(x => x.ValidUntil));
+            result.ValidUntil.Should().Be(validUntil);
+            result.Document.Should().BeEquivalentTo(claim.Document.ToDomain().ToResponse());
+        }
+
+        [Test]
+        public async Task Returns404WhenCannotFindClaim()
+        {
+            // Arrange - do not persist the claim
+            var claim = TestDataHelper.CreateClaim().ToEntity();
+
+            var validUntil = DateTime.UtcNow.AddDays(4);
+            var formattedValidUntil = JsonConvert.SerializeObject(validUntil);
+            string body = "{" +
+                          $"\"validUntil\": {formattedValidUntil}" +
+                          "}";
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/claims/{claim.Id}", UriKind.Relative);
+
+            // Act
+            var response = await Client.PatchAsync(uri, jsonString).ConfigureAwait(true);
+
+            // Assert
             response.StatusCode.Should().Be(404);
         }
 

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -170,6 +170,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 opts => opts.Excluding(x => x.ValidUntil));
             result.ValidUntil.Should().Be(validUntil);
             result.Document.Should().BeEquivalentTo(claim.Document.ToDomain().ToResponse());
+            // Check we have persisted the updated claim with a different ValidUntil date
+            DatabaseContext.Claims.Find(claim.Id).ValidUntil.Should().Be(validUntil);
         }
 
         [Test]

--- a/DocumentsApi.Tests/V1/UseCase/UpdateClaimStateUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/UpdateClaimStateUseCaseTests.cs
@@ -41,7 +41,8 @@ namespace DocumentsApi.Tests.V1.UseCase
             result.ValidUntil.Should().Be(validUntil);
         }
 
-        [Test] public void ThrowsAnErrorWhenRequestIsInvalid()
+        [Test]
+        public void ThrowsAnErrorWhenRequestIsInvalid()
         {
             // Arrange
             var id = Guid.NewGuid();

--- a/DocumentsApi.Tests/V1/UseCase/UpdateClaimStateUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/UpdateClaimStateUseCaseTests.cs
@@ -1,0 +1,79 @@
+using System;
+using DocumentsApi.V1.Boundary.Request;
+using DocumentsApi.V1.Boundary.Response.Exceptions;
+using DocumentsApi.V1.Gateways.Interfaces;
+using DocumentsApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace DocumentsApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class UpdateClaimStateUseCaseTests
+    {
+        private UpdateClaimStateUseCase _classUnderTest;
+        private Mock<IDocumentsGateway> _documentsGateway;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _documentsGateway = new Mock<IDocumentsGateway>();
+            _classUnderTest = new UpdateClaimStateUseCase(_documentsGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsTheUpdatedClaim()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var claim = TestDataHelper.CreateClaim();
+            claim.Id = id;
+            _documentsGateway.Setup(x => x.FindClaim(id)).Returns(claim);
+            var validUntil = DateTime.UtcNow.AddDays(5);
+            var claimUpdateRequest = CreateClaimUpdateRequest(validUntil);
+
+            // Act
+            var result = _classUnderTest.Execute(id, claimUpdateRequest);
+
+            // Assert
+            result.Id.Should().Be(claim.Id);
+            result.ValidUntil.Should().Be(validUntil);
+        }
+
+        [Test] public void ThrowsAnErrorWhenRequestIsInvalid()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            _documentsGateway.Setup(x => x.FindClaim(id)).Returns(TestDataHelper.CreateClaim);
+
+            // Act
+            Action act = () => _classUnderTest.Execute(id, null);
+
+            // Assert
+            act.Should().Throw<BadRequestException>().WithMessage($"Cannot update Claim with ID: {id} because of invalid request.");
+        }
+
+        [Test]
+        public void ThrowsAnErrorWhenClaimIsNotFound()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var claimUpdateRequest = CreateClaimUpdateRequest(DateTime.UtcNow);
+
+            // Act
+            Action act = () => _classUnderTest.Execute(id, claimUpdateRequest);
+
+            // Assert
+            act.Should().Throw<NotFoundException>().WithMessage($"Could not find Claim with ID: {id}");
+        }
+
+        private static ClaimUpdateRequest CreateClaimUpdateRequest(DateTime validUntil)
+        {
+            return new ClaimUpdateRequest()
+            {
+                ValidUntil = validUntil
+            };
+        }
+    }
+}

--- a/DocumentsApi/ServiceConfigurator.cs
+++ b/DocumentsApi/ServiceConfigurator.cs
@@ -1,4 +1,3 @@
-using System;
 using Amazon;
 using Amazon.S3;
 using DocumentsApi.V1.Gateways;
@@ -45,6 +44,7 @@ namespace DocumentsApi
             services.AddScoped<IUpdateUploadedDocumentUseCase, UpdateUploadedDocumentUseCase>();
             services.AddScoped<IFindClaimByIdUseCase, FindClaimByIdUseCase>();
             services.AddScoped<IDownloadDocumentUseCase, DownloadDocumentUseCase>();
+            services.AddScoped<IUpdateClaimStateUseCase, UpdateClaimStateUseCase>();
         }
     }
 }

--- a/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
@@ -8,5 +8,6 @@ namespace DocumentsApi.V1.Boundary.Request
         public string UserCreatedBy { get; set; }
         public string ApiCreatedBy { get; set; }
         public DateTime RetentionExpiresAt { get; set; }
+        public DateTime ValidUntil { get; set; }
     }
 }

--- a/DocumentsApi/V1/Boundary/Request/ClaimUpdateRequest.cs
+++ b/DocumentsApi/V1/Boundary/Request/ClaimUpdateRequest.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DocumentsApi.V1.Boundary.Request
+{
+    public class ClaimUpdateRequest
+    {
+        public DateTime ValidUntil { get; set; }
+    }
+}

--- a/DocumentsApi/V1/Factories/EntityFactory.cs
+++ b/DocumentsApi/V1/Factories/EntityFactory.cs
@@ -24,6 +24,7 @@ namespace DocumentsApi.V1.Factories
                 Id = domain.Id,
                 CreatedAt = domain.CreatedAt,
                 Document = domain.Document?.ToEntity(),
+                DocumentId = domain.Document.Id,
                 ApiCreatedBy = domain.ApiCreatedBy,
                 UserCreatedBy = domain.UserCreatedBy,
                 ServiceAreaCreatedBy = domain.ServiceAreaCreatedBy,

--- a/DocumentsApi/V1/Gateways/DocumentsGateway.cs
+++ b/DocumentsApi/V1/Gateways/DocumentsGateway.cs
@@ -61,6 +61,7 @@ namespace DocumentsApi.V1.Gateways
         public Claim SaveClaim(Claim request)
         {
             var entity = request.ToEntity();
+            _databaseContext.Entry(entity).State = EntityState.Modified;
             _databaseContext.SaveChanges();
 
             return entity.ToDomain();

--- a/DocumentsApi/V1/Gateways/DocumentsGateway.cs
+++ b/DocumentsApi/V1/Gateways/DocumentsGateway.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using DocumentsApi.V1.Domain;
 using DocumentsApi.V1.Factories;
 using DocumentsApi.V1.Gateways.Interfaces;
@@ -56,6 +55,14 @@ namespace DocumentsApi.V1.Gateways
             entity.Document = document;
 
             _databaseContext.Entry(entity).State = EntityState.Detached;
+            return entity.ToDomain();
+        }
+
+        public Claim SaveClaim(Claim request)
+        {
+            var entity = request.ToEntity();
+            _databaseContext.SaveChanges();
+
             return entity.ToDomain();
         }
     }

--- a/DocumentsApi/V1/Gateways/Interfaces/IDocumentsGateway.cs
+++ b/DocumentsApi/V1/Gateways/Interfaces/IDocumentsGateway.cs
@@ -9,5 +9,6 @@ namespace DocumentsApi.V1.Gateways.Interfaces
         public Claim CreateClaim(Claim request);
         public Document FindDocument(Guid id);
         public Claim FindClaim(Guid id);
+        public Claim SaveClaim(Claim request);
     }
 }

--- a/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
@@ -6,7 +6,6 @@ using DocumentsApi.V1.Boundary.Response.Exceptions;
 using DocumentsApi.V1.Domain;
 using DocumentsApi.V1.Factories;
 using DocumentsApi.V1.Gateways.Interfaces;
-using DocumentsApi.V1.Infrastructure;
 using DocumentsApi.V1.UseCase.Interfaces;
 using DocumentsApi.V1.Validators;
 
@@ -45,7 +44,7 @@ namespace DocumentsApi.V1.UseCase
                 ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
                 UserCreatedBy = request.UserCreatedBy,
                 RetentionExpiresAt = request.RetentionExpiresAt,
-                ValidUntil = DateTime.UtcNow.AddMonths(3), // temporary until we source it from ClaimRequest
+                ValidUntil = request.ValidUntil,
                 // TODO: Support creating claims for existing documents
                 Document = new Document()
             };

--- a/DocumentsApi/V1/UseCase/Interfaces/IUpdateClaimStateUseCase.cs
+++ b/DocumentsApi/V1/UseCase/Interfaces/IUpdateClaimStateUseCase.cs
@@ -1,0 +1,11 @@
+using System;
+using DocumentsApi.V1.Boundary.Request;
+using DocumentsApi.V1.Boundary.Response;
+
+namespace DocumentsApi.V1.UseCase.Interfaces
+{
+    public interface IUpdateClaimStateUseCase
+    {
+        ClaimResponse Execute(Guid id, ClaimUpdateRequest request);
+    }
+}

--- a/DocumentsApi/V1/UseCase/UpdateClaimStateUseCase.cs
+++ b/DocumentsApi/V1/UseCase/UpdateClaimStateUseCase.cs
@@ -1,0 +1,40 @@
+using System;
+using DocumentsApi.V1.Boundary.Request;
+using DocumentsApi.V1.Boundary.Response;
+using DocumentsApi.V1.Boundary.Response.Exceptions;
+using DocumentsApi.V1.Factories;
+using DocumentsApi.V1.Gateways.Interfaces;
+using DocumentsApi.V1.UseCase.Interfaces;
+
+namespace DocumentsApi.V1.UseCase
+{
+    public class UpdateClaimStateUseCase : IUpdateClaimStateUseCase
+    {
+        private readonly IDocumentsGateway _documentsGateway;
+
+        public UpdateClaimStateUseCase(IDocumentsGateway documentsGateway)
+        {
+            _documentsGateway = documentsGateway;
+        }
+
+        public ClaimResponse Execute(Guid id, ClaimUpdateRequest request)
+        {
+            var found = _documentsGateway.FindClaim(id);
+
+            if (found == null)
+            {
+                throw new NotFoundException($"Could not find Claim with ID: {id}");
+            }
+
+            if (request == null)
+            {
+                throw new BadRequestException($"Cannot update Claim with ID: {id} because of invalid request.");
+            }
+
+            found.ValidUntil = request.ValidUntil;
+            _documentsGateway.SaveClaim(found);
+
+            return found.ToResponse();
+        }
+    }
+}


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-210

- Added `ValidUntil ` to `ClaimRequest` because I wanted to following `RetentionExpiresAt` where EvidenceAPI provides the default value (3 months)