### PR TITLE
Reference subnets by name

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -40,8 +40,8 @@ data "aws_vpc" "staging_vpc" {
 data "aws_subnet_ids" "staging" {
   vpc_id = data.aws_vpc.staging_vpc.id
   filter {
-    name   = "tag:Type"
-    values = ["private"]
+    name   = "tag:Name"
+    values = ["des-app-stg-private-eu-west-2a", "des-app-stg-private-eu-west-2b"]
   }
 }
 


### PR DESCRIPTION
Reference subnets by name tag instead of type tag as the latter does not exist