### PR TITLE
Update lambda orchestrator to call DocumentsS3Function(serverless)

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -49,8 +49,12 @@ def lambda_handler(event, context):
    print("Deleting the originial file")
    print("s3_client.delete_object", bucket_name, file_key_name)
    s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
-
    # now we can delete the file in the pre_scan bucket as it has been copied to post_scan
+
+   response = s3_client.invoke(
+       FunctionName = 'arn:aws:lambda:eu-west-2:549011513230:function:documents-api-staging-s3'
+   )
+   print("s3_client.invoke", response)
 
    return {
        'statusCode': 200,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/projects/DES/boards/45?selectedIssue=DES-254

## Describe this PR

### *What changes have we introduced*

Updated the lambda orchestrator to call another lambda (DocumentsS3Function in serverless) when the file doesn't contain malware.