### PR TITLE
DES-254: app deployment should be dependent on database migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ workflows:
             - assume-role-staging
       - deploy-to-staging:
           requires:
-            - assume-role-staging
+            - migrate-database-staging
 
       # Production deploy
       - permit-production-release:
@@ -206,4 +206,4 @@ workflows:
             - assume-role-production
       - deploy-to-production:
           requires:
-            - assume-role-production
+            - migrate-database-production


### PR DESCRIPTION
We should deploy the app only if database migration finishes successfully, otherwise we may deploy code changes that depend on database changes which weren't deployed