### PR TITLE
Add endpoint for getting a claim and document and refactor

### DIFF
--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -161,5 +161,108 @@ namespace DocumentsApi.Tests.V1.E2ETests
             response.StatusCode.Should().Be(404);
         }
 
+        [Test]
+        public async Task Returns200WhenItCanGetClaimAndDocument()
+        {
+            var claim = TestDataHelper.CreateClaim().ToEntity();
+            DatabaseContext.Add(claim);
+            DatabaseContext.Add(claim.Document);
+            DatabaseContext.SaveChanges();
+
+            var uri = new Uri($"api/v1/claims/claim_and_document/{claim.Id}", UriKind.Relative);
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var result = JsonConvert.DeserializeObject<ClaimAndDocumentResponse>(jsonString);
+
+            response.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public async Task Returns400WhenClaimAndDocumentRequestIsNotValid()
+        {
+            var claim = TestDataHelper.CreateClaim().ToEntity();
+            DatabaseContext.Add(claim);
+            DatabaseContext.Add(claim.Document);
+            DatabaseContext.SaveChanges();
+            var fakeClaimId = Guid.NewGuid();
+
+            var uri = new Uri($"api/v1/claims/claim_and_document/${fakeClaimId}", UriKind.Relative);
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var result = JsonConvert.DeserializeObject<ClaimAndDocumentResponse>(jsonString);
+
+            response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task CanCreateClaimAndDocument()
+        {
+            var uri = new Uri($"api/v1/claims/claim_and_document", UriKind.Relative);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
+            var formattedValidUntil = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(4));
+            string base64Document = "data:@file/plain;base64,VGhpcyBpcyBhIHRlc3QgZmlsZQ==";
+            string body = "{" +
+                "\"serviceAreaCreatedBy\": \"development-team-staging\"," +
+                "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
+                "\"apiCreatedBy\": \"evidence-api\"," +
+                $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
+                $"\"validUntil\": {formattedValidUntil}," +
+                $"\"base64Document\": \"{base64Document}\"" +
+                "}";
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(201);
+
+            var claim = DatabaseContext.Claims.First();
+            var document = DatabaseContext.Documents.First();
+
+            var formattedCreatedAt = JsonConvert.SerializeObject(claim.CreatedAt);
+            var formattedDocumentCreatedAt = JsonConvert.SerializeObject(document.CreatedAt);
+            string expected = "{" +
+                              $"\"claimId\":\"{claim.Id}\"," +
+                              $"\"createdAt\":{formattedCreatedAt}," +
+                              "\"document\":{" +
+                                  $"\"id\":\"{document.Id}\"," +
+                                  $"\"createdAt\":{formattedDocumentCreatedAt}," +
+                                  "\"fileSize\":0," +
+                                  "\"fileType\":null," +
+                                  "\"uploadedAt\":null" +
+                              "}," +
+                              "\"serviceAreaCreatedBy\":\"development-team-staging\"," +
+                              "\"userCreatedBy\":\"staff@test.hackney.gov.uk\"," +
+                              "\"apiCreatedBy\":\"evidence-api\"," +
+                              $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
+                              $"\"validUntil\":{formattedValidUntil}," +
+                              $"\"base64Document\":\"{base64Document}\"" +
+                              "}";
+
+            json.Should().Be(expected);
+        }
+
+        [Test]
+        public async Task ClaimAndDocumentReturnsBadRequestWithInvalidParams()
+        {
+            var uri = new Uri($"api/v1/claims/claim_and_document", UriKind.Relative);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
+            var formattedValidUntil = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(4));
+            string base64Document = "data:@file/plain;base64,VGhpcyBpcyBhIHRlc3QgZmlsZQ==";
+            string body = "{" +
+                "\"serviceAreaCreatedBy\": \"development-team-staging\"," +
+                "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
+                "\"apiCreatedBy\": " +
+                $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
+                $"\"validUntil\": {formattedValidUntil}," +
+                $"\"base64Document\": \"{base64Document}\"" +
+                "}";
+
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(400);
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -25,7 +25,7 @@ namespace DocumentsApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapAClaimDomainModelAndBase64DocumentToResponse()
+        public void CanMapAClaimAndBase64DocumentToResponse()
         {
             var document = _fixture.Create<DocumentResponse>();
             var claim = _fixture.Build<ClaimResponse>()
@@ -33,10 +33,10 @@ namespace DocumentsApi.Tests.V1.Factories
                 .Create();
             var base64Document = "base-64-document";
 
-            var response = claim.ToClaimAndUploadDocumentResponse(base64Document);
-            ClaimAndUploadDocumentResponse expected = new ClaimAndUploadDocumentResponse
+            var response = claim.ToClaimAndDocumentResponse(base64Document);
+            ClaimAndDocumentResponse expected = new ClaimAndDocumentResponse
             {
-                Id = response.Id,
+                ClaimId = response.ClaimId,
                 CreatedAt = response.CreatedAt,
                 Document = response.Document,
                 ServiceAreaCreatedBy = response.ServiceAreaCreatedBy,

--- a/DocumentsApi.Tests/V1/UseCase/GetClaimAndDocumentUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/GetClaimAndDocumentUseCaseTests.cs
@@ -1,0 +1,34 @@
+using System;
+using DocumentsApi.V1.UseCase.Interfaces;
+using DocumentsApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Microsoft.Extensions.Logging;
+
+namespace DocumentsApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class GetClaimAndDocumentUseCaseTests
+    {
+        private readonly GetClaimAndDocumentUseCase _classUnderTest;
+        private readonly Mock<IFindClaimByIdUseCase> _findClaimByIdUseCase = new Mock<IFindClaimByIdUseCase>();
+        private readonly Mock<IDownloadDocumentUseCase> _downloadDocumentUseCase = new Mock<IDownloadDocumentUseCase>();
+        private readonly Mock<ILogger<GetClaimAndDocumentUseCase>> _logger = new Mock<ILogger<GetClaimAndDocumentUseCase>>();
+
+        public GetClaimAndDocumentUseCaseTests()
+        {
+            _classUnderTest = new GetClaimAndDocumentUseCase(_findClaimByIdUseCase.Object, _downloadDocumentUseCase.Object, _logger.Object);
+        }
+
+        [Test]
+        public void ReturnsCorrectResponse()
+        {
+            var claimId = Guid.NewGuid();
+
+            Action execute = () => _classUnderTest.Execute(claimId);
+
+            execute.Should().NotBeNull();
+        }
+    }
+}

--- a/DocumentsApi/ServiceConfigurator.cs
+++ b/DocumentsApi/ServiceConfigurator.cs
@@ -44,6 +44,7 @@ namespace DocumentsApi
             services.AddScoped<IUpdateClaimStateUseCase, UpdateClaimStateUseCase>();
             services.AddScoped<IUploadDocumentUseCase, UploadDocumentUseCase>();
             services.AddScoped<ICreateClaimAndUploadDocumentUseCase, CreateClaimAndUploadDocumentUseCase>();
+            services.AddScoped<IGetClaimAndDocumentUseCase, GetClaimAndDocumentUseCase>();
         }
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimAndDocumentResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimAndDocumentResponse.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace DocumentsApi.V1.Boundary.Response
 {
-    public class ClaimAndUploadDocumentResponse
+    public class ClaimAndDocumentResponse
     {
-        public Guid Id { get; set; }
+        public Guid ClaimId { get; set; }
         public DateTime CreatedAt { get; set; }
         public DocumentResponse Document { get; set; }
         public string ServiceAreaCreatedBy { get; set; }

--- a/DocumentsApi/V1/Factories/ResponseFactory.cs
+++ b/DocumentsApi/V1/Factories/ResponseFactory.cs
@@ -32,15 +32,15 @@ namespace DocumentsApi.V1.Factories
             };
         }
 
-        public static ClaimAndUploadDocumentResponse ToClaimAndUploadDocumentResponse(this ClaimResponse claim, string base64Document)
+        public static ClaimAndDocumentResponse ToClaimAndDocumentResponse(this ClaimResponse claim, string base64Document)
         {
-            return new ClaimAndUploadDocumentResponse
+            return new ClaimAndDocumentResponse
             {
                 ApiCreatedBy = claim.ApiCreatedBy,
                 CreatedAt = claim.CreatedAt,
                 Document = claim.Document,
                 ServiceAreaCreatedBy = claim.ServiceAreaCreatedBy,
-                Id = claim.Id,
+                ClaimId = claim.Id,
                 RetentionExpiresAt = claim.RetentionExpiresAt,
                 UserCreatedBy = claim.UserCreatedBy,
                 ValidUntil = claim.ValidUntil,

--- a/DocumentsApi/V1/UseCase/CreateClaimAndUploadDocumentUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimAndUploadDocumentUseCase.cs
@@ -22,7 +22,7 @@ namespace DocumentsApi.V1.UseCase
             _logger = logger;
         }
 
-        public ClaimAndUploadDocumentResponse Execute(ClaimAndUploadDocumentRequest request)
+        public ClaimAndDocumentResponse Execute(ClaimAndUploadDocumentRequest request)
         {
             var validation = new ClaimAndUploadDocumentRequestValidator().Validate(request);
             if (!validation.IsValid)
@@ -35,7 +35,7 @@ namespace DocumentsApi.V1.UseCase
             var claim = _createClaimUseCase.Execute(claimRequest);
             _uploadDocumentUseCase.Execute(claim.Document.Id, documentUploadRequest);
 
-            return claim.ToClaimAndUploadDocumentResponse(request.Base64Document);
+            return claim.ToClaimAndDocumentResponse(request.Base64Document);
         }
 
         private static ClaimRequest BuildClaimRequest(ClaimAndUploadDocumentRequest request)

--- a/DocumentsApi/V1/UseCase/GetClaimAndDocumentUseCase.cs
+++ b/DocumentsApi/V1/UseCase/GetClaimAndDocumentUseCase.cs
@@ -1,0 +1,33 @@
+using System;
+using DocumentsApi.V1.Boundary.Response;
+using DocumentsApi.V1.Factories;
+using DocumentsApi.V1.UseCase.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace DocumentsApi.V1.UseCase
+{
+    public class GetClaimAndDocumentUseCase : IGetClaimAndDocumentUseCase
+    {
+        private readonly IFindClaimByIdUseCase _findClaimByIdUseCase;
+        private readonly IDownloadDocumentUseCase _downloadDocumentUseCase;
+        private readonly ILogger<GetClaimAndDocumentUseCase> _logger;
+
+        public GetClaimAndDocumentUseCase(
+            IFindClaimByIdUseCase findClaimByIdUseCase,
+            IDownloadDocumentUseCase downloadDocumentUseCase,
+            ILogger<GetClaimAndDocumentUseCase> logger)
+        {
+            _findClaimByIdUseCase = findClaimByIdUseCase;
+            _downloadDocumentUseCase = downloadDocumentUseCase;
+            _logger = logger;
+        }
+
+        public ClaimAndDocumentResponse Execute(Guid claimId)
+        {
+            var claim = _findClaimByIdUseCase.Execute(claimId);
+            var document = _downloadDocumentUseCase.Execute(claim.Document.Id);
+
+            return claim.ToClaimAndDocumentResponse(document);
+        }
+    }
+}

--- a/DocumentsApi/V1/UseCase/Interfaces/ICreateClaimAndUploadDocumentUseCase.cs
+++ b/DocumentsApi/V1/UseCase/Interfaces/ICreateClaimAndUploadDocumentUseCase.cs
@@ -5,6 +5,6 @@ namespace DocumentsApi.V1.UseCase.Interfaces
 {
     public interface ICreateClaimAndUploadDocumentUseCase
     {
-        public ClaimAndUploadDocumentResponse Execute(ClaimAndUploadDocumentRequest request);
+        public ClaimAndDocumentResponse Execute(ClaimAndUploadDocumentRequest request);
     }
 }

--- a/DocumentsApi/V1/UseCase/Interfaces/IGetClaimAndDocumentUseCase.cs
+++ b/DocumentsApi/V1/UseCase/Interfaces/IGetClaimAndDocumentUseCase.cs
@@ -1,0 +1,10 @@
+using System;
+using DocumentsApi.V1.Boundary.Response;
+
+namespace DocumentsApi.V1.UseCase.Interfaces
+{
+    public interface IGetClaimAndDocumentUseCase
+    {
+        public ClaimAndDocumentResponse Execute(Guid claimId);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-326

## Describe this PR

### *What changes have we introduced*

- Added a new endpoint to be able to get a claim and the associated document by making just one request instead of two
- Refactor the endpoint to create a claim and document to use the same response object as the new endpoint as the shape of the response for both endpoints is identical
- Added E2E tests to cover both endpoints

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
