### PR TITLE
Amend FindClaimByIdUseCase so it returns expired claims

### DIFF
--- a/DocumentsApi.Tests/V1/UseCase/FindClaimByIdUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/FindClaimByIdUseCaseTests.cs
@@ -45,6 +45,7 @@ namespace DocumentsApi.Tests.V1.UseCase
         }
 
         [Test]
+        [Ignore("we want to currently return expired claims")]
         public void ThrowsNotFoundIfClaimHasExpired()
         {
             var claim = TestDataHelper.CreateClaim();

--- a/DocumentsApi/V1/UseCase/FindClaimByIdUseCase.cs
+++ b/DocumentsApi/V1/UseCase/FindClaimByIdUseCase.cs
@@ -20,7 +20,7 @@ namespace DocumentsApi.V1.UseCase
         {
             var found = _documentsGateway.FindClaim(id);
 
-            if (found == null || found.Expired)
+            if (found == null)
             {
                 throw new NotFoundException($"Could not find Claim with ID {id}");
             }


### PR DESCRIPTION
This commit quickly fixes the issue where an officer was not able to view the claims and documents of a resident, because one claim was expired. This fix now allows expired claims to render on the frontend.