### PR TITLE
Doc 417

### DIFF
--- a/DocumentsApi/V1/Controllers/DocumentsController.cs
+++ b/DocumentsApi/V1/Controllers/DocumentsController.cs
@@ -36,7 +36,7 @@ namespace DocumentsApi.V1.Controllers
         /// <response code="201">Saved</response>
         /// <response code="400">Request contains invalid parameters</response>
         /// <response code="401">Request lacks valid API token</response>
-        [HttpPost]
+        [HttpGet]
         [Route("upload_policies")]
         public async Task<IActionResult> CreateUploadPolicy()
         {

--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -15,7 +15,7 @@ provider:
     apiGateway: true
     lambda: true
   environment:
-    CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password~true}
+    CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password}
     BUCKET_NAME: document-evidence-store-${self:provider.stage}-bucket
   s3:
     documentsBucket:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

HTTP method for CreateUploadPolicy in the Documents controller was a POST instead of GET. 

Additionally, error in CI that states that:

`Error:
Cannot resolve serverless.yml: Variables resolution errored with:
  - Cannot resolve variable at "provider.environment.CONNECTION_STRING": Parameter name: can't be prefixed with "ssm" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_
`

### *What changes have we introduced*

Updated HTTP method in DocumentsController for upload_policies endpoint and updated serverless.yml to remove `~true`.

See EvidenceApi for more information about serverless.yml: https://github.com/LBHackney-IT/evidence-api/pull/125#issue-1123145780

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
