### PR TITLE
Change return to handle Promise object

### DIFF
--- a/DocumentsApi/V1/Node/index.js
+++ b/DocumentsApi/V1/Node/index.js
@@ -31,7 +31,7 @@ module.exports = (callback, bucketName, key, expiry) => {
             ],
         });
 
-        return callback(null, JSON.stringify(data));
+        data.then(result => callback(null, JSON.stringify(result)));
     } catch (err) {
         console.log("Failed generating pre-signed upload url", {
             error: err,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

The call the Amazon S3 is currently returning a 200, but the object is empty. We think that the call is not awaiting the presigned url to come back from S3. We tried turning the function into an async, but this conflicts with the behaviour of the callback.

### *What changes have we introduced*

S3 returns a Promise object, so we need to handle this using .then.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
