### PR TITLE
Amend document orchestrator to check for MIME types

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -3,73 +3,73 @@ import boto3
 import botocore
 
 def lambda_handler(event, context):
-   # Disable SSL for this instance of the client so that when we call 'download_file' then Palo Altos is able to scan the payload for malware
-   s3_client_no_ssl = boto3.client('s3', use_ssl=False)
-   # Enable SSL for other S3 operations
-   s3_client = boto3.client('s3')
-   lambda_client = boto3.client("lambda")
+    # Disable SSL for this instance of the client so that when we call 'download_file' then Palo Altos is able to scan the payload for malware
+    s3_client_no_ssl = boto3.client('s3', use_ssl=False)
+    # Enable SSL for other S3 operations
+    s3_client = boto3.client('s3')
+    lambda_client = boto3.client("lambda")
 
-   # event contains all information about uploaded object
-   print("Event :", event)
+    # event contains all information about uploaded object
+    print("Event :", event)
 
-   # Bucket Name where file was uploaded
-   bucket_name = event['Records'][0]['s3']['bucket']['name']
+    # Bucket Name where file was uploaded
+    bucket_name = event['Records'][0]['s3']['bucket']['name']
 
-   # Filename of object (with path)
-   file_key_name = event['Records'][0]['s3']['object']['key']
+    # Filename of object (with path)
+    file_key_name = event['Records'][0]['s3']['object']['key']
 
-   # Copy Source Object
-   copy_source_object = {'Bucket': bucket_name, 'Key': file_key_name}
+    # Copy Source Object
+    copy_source_object = {'Bucket': bucket_name, 'Key': file_key_name}
 
-   #Whitelist of accepted MIME types
-   accepted_mime_types = [
-    'application/msword', #.doc
-    'application/pdf', #.pdf
-    'application/vnd.apple.numbers', #.numbers
-    'application/vnd.apple.pages', #.pages
-    'application/vnd.ms-excel', #.xls
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', #.xlsx
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document', #.docx
-    'image/bmp', #.bmp
-    'image/gif', #.gif
-    'image/heic', #.heic
-    'image/jpeg', #.jpeg or .jpg
-    'image/png', #.png
-    'text/plain', #.txt
-    #'video/3gpp', #.3gpp or .3gp
-    #'video/mp4', #.mp4
-    #'video/quicktime', #.mov or .qt
-   ] 
+    #Whitelist of accepted MIME types
+    accepted_mime_types = [
+        'application/msword', #.doc
+        'application/pdf', #.pdf
+        'application/vnd.apple.numbers', #.numbers
+        'application/vnd.apple.pages', #.pages
+        'application/vnd.ms-excel', #.xls
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', #.xlsx
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document', #.docx
+        'image/bmp', #.bmp
+        'image/gif', #.gif
+        'image/heic', #.heic
+        'image/jpeg', #.jpeg or .jpg
+        'image/png', #.png
+        'text/plain', #.txt
+        #'video/3gpp', #.3gpp or .3gp
+        #'video/mp4', #.mp4
+        #'video/quicktime', #.mov or .qt
+    ] 
 
    #Check for MIME type of file
-   head_object = s3_client.head_object(
-       Bucket=bucket_name,
-       Key=file_key_name,
-   )
+    head_object = s3_client.head_object(
+        Bucket=bucket_name,
+        Key=file_key_name,
+    )
     
-   if head_object['ContentType'] not in accepted_mime_types:
-      print(f"File type {head_object['ContentType']} is not accepted!")
-      print("Deleting the original file")
-      print("s3_client.delete_object", bucket_name, file_key_name)
-      s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
-      return {
-        'statusCode': 200,
-        'body': json.dumps('Document Orchestrator finished successfully')
-      }
+    if head_object['ContentType'] not in accepted_mime_types:
+        print(f"File type {head_object['ContentType']} is not accepted!")
+        print("Deleting the original file")
+        print("s3_client.delete_object", bucket_name, file_key_name)
+        s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
+        return {
+            'statusCode': 200,
+            'body': json.dumps('Document Orchestrator finished successfully')
+        }
 
-   # If MIME type is accepted, we can continue and copy the file
-   try:
-       # Get filename only and prepend with tmp as this is the only ephemeral storage lambdas have
-       download_path = '/tmp/' + file_key_name.split('/')[-1]
-       print("s3_client.download_file", bucket_name, file_key_name, download_path)
-       s3_client_no_ssl.download_file(bucket_name, file_key_name, download_path)
+    # If MIME type is accepted, we can continue and copy the file
+    try:
+        # Get filename only and prepend with tmp as this is the only ephemeral storage lambdas have
+        download_path = '/tmp/' + file_key_name.split('/')[-1]
+        print("s3_client.download_file", bucket_name, file_key_name, download_path)
+        s3_client_no_ssl.download_file(bucket_name, file_key_name, download_path)
 
-   except Exception as e:
+    except Exception as e:
         print('An exception occurred: {}'.format(e))
         print("There was an error when attempting to download the file, moving to quarantine")
         move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client)
 
-   move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client)
+    move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client)
    
 
 def move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client):

--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -1,4 +1,3 @@
-from distutils.file_util import move_file
 import json
 import boto3
 import botocore

--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -1,3 +1,4 @@
+from distutils.file_util import move_file
 import json
 import boto3
 import botocore
@@ -21,7 +22,43 @@ def lambda_handler(event, context):
    # Copy Source Object
    copy_source_object = {'Bucket': bucket_name, 'Key': file_key_name}
 
-   # If this is successful we can continue and copy the file
+   #Whitelist of accepted MIME types
+   accepted_mime_types = [
+    'application/msword', #.doc
+    'application/pdf', #.pdf
+    'application/vnd.apple.numbers', #.numbers
+    'application/vnd.apple.pages', #.pages
+    'application/vnd.ms-excel', #.xls
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', #.xlsx
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document', #.docx
+    'image/bmp', #.bmp
+    'image/gif', #.gif
+    'image/heic', #.heic
+    'image/jpeg', #.jpeg or .jpg
+    'image/png', #.png
+    'text/plain', #.txt
+    #'video/3gpp', #.3gpp or .3gp
+    #'video/mp4', #.mp4
+    #'video/quicktime', #.mov or .qt
+   ] 
+
+   #Check for MIME type of file
+   head_object = s3_client.head_object(
+       Bucket=bucket_name,
+       Key=file_key_name,
+   )
+    
+   if head_object['ContentType'] not in accepted_mime_types:
+      print(f"File type {head_object['ContentType']} is not accepted!")
+      print("Deleting the original file")
+      print("s3_client.delete_object", bucket_name, file_key_name)
+      s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
+      return {
+        'statusCode': 200,
+        'body': json.dumps('Document Orchestrator finished successfully')
+      }
+
+   # If MIME type is accepted, we can continue and copy the file
    try:
        # Get filename only and prepend with tmp as this is the only ephemeral storage lambdas have
        download_path = '/tmp/' + file_key_name.split('/')[-1]
@@ -31,37 +68,44 @@ def lambda_handler(event, context):
    except Exception as e:
         print('An exception occurred: {}'.format(e))
         print("There was an error when attempting to download the file, moving to quarantine")
+        move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client)
 
-        quarantine_file_key_name = file_key_name.replace('pre-scan/', 'quarantine/')
-        print("s3_client.copy_object", copy_source_object, bucket_name, quarantine_file_key_name)
-        s3_client.copy_object(CopySource=copy_source_object, Bucket=bucket_name, Key=quarantine_file_key_name)
+   move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client)
+   
 
-        print("Deleting the original file")
-        print("s3_client.delete_object", bucket_name, file_key_name)
-        s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
-        return {
-           'statusCode': 200,
-           'body': json.dumps('Document Orchestrator finished successfully')
-        }
+def move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client):
+    quarantine_file_key_name = file_key_name.replace('pre-scan/', 'quarantine/')
+    print("s3_client.copy_object", copy_source_object, bucket_name, quarantine_file_key_name)
+    s3_client.copy_object(CopySource=copy_source_object, Bucket=bucket_name, Key=quarantine_file_key_name)
 
-   clean_file_key_name  = file_key_name.replace('pre-scan/', 'clean/')
-   print("s3_client.copy_object", copy_source_object, bucket_name, clean_file_key_name)
-   s3_client.copy_object(CopySource=copy_source_object, Bucket=bucket_name, Key=clean_file_key_name)
+    print("Deleting the original file")
+    print("s3_client.delete_object", bucket_name, file_key_name)
+    s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Document Orchestrator finished successfully')
+    }
 
-   print("Deleting the original file")
-   print("s3_client.delete_object", bucket_name, file_key_name)
-   s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
+def move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client):
+    clean_file_key_name  = file_key_name.replace('pre-scan/', 'clean/')
+    print("s3_client.copy_object", copy_source_object, bucket_name, clean_file_key_name)
+    s3_client.copy_object(CopySource=copy_source_object, Bucket=bucket_name, Key=clean_file_key_name)
 
-   print("Invoking documents-api-malware-scan-successful", clean_file_key_name)
-   # Update the event object with the updated key now we've moved the file to the clean directory. Send this payload to the next lambda
-   event['Records'][0]['s3']['object']['key'] = clean_file_key_name
-   response = lambda_client.invoke(
-       FunctionName = 'documents-api-malware-scan-successful',
-       Payload = json.dumps(event)
-   )
-   print("Response of lambda_client.invoke", response)
+    print("Deleting the original file")
+    print("s3_client.delete_object", bucket_name, file_key_name)
+    s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
 
-   return {
-       'statusCode': 200,
-       'body': json.dumps('Document Orchestrator finished successfully')
-   }
+    print("Invoking documents-api-malware-scan-successful", clean_file_key_name)
+    # Update the event object with the updated key now we've moved the file to the clean directory. 
+    # Send this payload to the next lambda, which calls the UpdateUploadedDocumentUseCase that updates database with Size, UploadedAt and FileType
+    event['Records'][0]['s3']['object']['key'] = clean_file_key_name
+    response = lambda_client.invoke(
+        FunctionName = 'documents-api-malware-scan-successful',
+        Payload = json.dumps(event)
+    )
+    print("Response of lambda_client.invoke", response)
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Document Orchestrator finished successfully')
+    }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

We need to check for MIME types when we upload documents to S3.

Why? This is because after our pen-test, it was highlighted that we need to do client- and server-side validation of Content-Types. Due to our new approach to uploading documents, we can no longer enforce a Content-Type check at the server, neither when we are specifying a condition for the policy (because we don't know what the Content-Type is at this stage). However, we can do this when the Document Orchestrator lambda is run to scan for malware.

### *What changes have we introduced*

We have introduced a check for accepted MIME types in this script. If a file does not pass the check, it is deleted from the bucket. The documents-api database is then not updated with the file metadata needed for the document entity and an officer cannot view it.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
