### PR TITLE
Add content type to policy and remove print statement

### DIFF
--- a/DocumentsApi/V1/Node/index.js
+++ b/DocumentsApi/V1/Node/index.js
@@ -27,7 +27,7 @@ module.exports = (callback, bucketName, key, expiry) => {
                 { key },
                 { "x-amz-server-side-encryption": "AES256" },
                 ["content-length-range", 1, 10000000], // value is in bytes -> 10mb
-                ["starts-with", "$Content-Type", ""],
+                ["starts-with", "$Content-Type", "image/"],
             ],
         });
 

--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -48,7 +48,6 @@ def lambda_handler(event, context):
     )
 
     print(f"***********head_object: {head_object}")
-    print(f"***********head_object.body: {head_object.body}")
     print(f"***********head_object.headers: {head_object.headers}")
     
     if head_object['ContentType'] not in accepted_mime_types:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

Content Type that is being returned from AWS is `'ContentType': '""'`. We wonder whether this content type is coming from the file itself or from when we declare it as part of the upload policy. We'll upload a file that specifies PNG to test this.

### *What changes have we introduced*

Add content type to policy and remove erroring print statement

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
