### PR TITLE
Comment out file type validation and amend policy

### DIFF
--- a/DocumentsApi/V1/Node/index.js
+++ b/DocumentsApi/V1/Node/index.js
@@ -26,8 +26,8 @@ module.exports = (callback, bucketName, key, expiry) => {
                 { acl: "private" },
                 { key },
                 { "x-amz-server-side-encryption": "AES256" },
-                ["content-length-range", 1, 10000000], // value is in bytes -> 10mb
-                ["starts-with", "$Content-Type", "image/"],
+                ["content-length-range", 1, 50000000], // value is in bytes -> 50mb
+                ["starts-with", "$Content-Type", ""],
             ],
         });
 

--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -22,43 +22,42 @@ def lambda_handler(event, context):
     copy_source_object = {'Bucket': bucket_name, 'Key': file_key_name}
 
     #Whitelist of accepted MIME types
-    accepted_mime_types = [
-        'application/msword', #.doc
-        'application/pdf', #.pdf
-        'application/vnd.apple.numbers', #.numbers
-        'application/vnd.apple.pages', #.pages
-        'application/vnd.ms-excel', #.xls
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', #.xlsx
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document', #.docx
-        'image/bmp', #.bmp
-        'image/gif', #.gif
-        'image/heic', #.heic
-        'image/jpeg', #.jpeg or .jpg
-        'image/png', #.png
-        'text/plain', #.txt
-        #'video/3gpp', #.3gpp or .3gp
-        #'video/mp4', #.mp4
-        #'video/quicktime', #.mov or .qt
-    ] 
+    # accepted_mime_types = [
+    #     'application/msword', #.doc
+    #     'application/pdf', #.pdf
+    #     'application/vnd.apple.numbers', #.numbers
+    #     'application/vnd.apple.pages', #.pages
+    #     'application/vnd.ms-excel', #.xls
+    #     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', #.xlsx
+    #     'application/vnd.openxmlformats-officedocument.wordprocessingml.document', #.docx
+    #     'image/bmp', #.bmp
+    #     'image/gif', #.gif
+    #     'image/heic', #.heic
+    #     'image/jpeg', #.jpeg or .jpg
+    #     'image/png', #.png
+    #     'text/plain', #.txt
+    #     #'video/3gpp', #.3gpp or .3gp
+    #     #'video/mp4', #.mp4
+    #     #'video/quicktime', #.mov or .qt
+    # ] 
 
    #Check for MIME type of file
-    head_object = s3_client.head_object(
-        Bucket=bucket_name,
-        Key=file_key_name,
-    )
+    # head_object = s3_client.head_object(
+    #     Bucket=bucket_name,
+    #     Key=file_key_name,
+    # )
 
-    print(f"***********head_object: {head_object}")
-    print(f"***********head_object.headers: {head_object.headers}")
+    # print(f"***********head_object: {head_object}")
     
-    if head_object['ContentType'] not in accepted_mime_types:
-        print(f"File type {head_object['ContentType']} is not accepted!")
-        print("Deleting the original file")
-        print("s3_client.delete_object", bucket_name, file_key_name)
-        s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
-        return {
-            'statusCode': 200,
-            'body': json.dumps('Document Orchestrator finished successfully')
-        }
+    # if head_object['ContentType'] not in accepted_mime_types:
+    #     print(f"File type {head_object['ContentType']} is not accepted!")
+    #     print("Deleting the original file")
+    #     print("s3_client.delete_object", bucket_name, file_key_name)
+    #     s3_client.delete_object(Bucket=bucket_name, Key=file_key_name)
+    #     return {
+    #         'statusCode': 200,
+    #         'body': json.dumps('Document Orchestrator finished successfully')
+    #     }
 
     # If MIME type is accepted, we can continue and copy the file
     try:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

Validation for content-type will not work at the moment.

We've discovered that `head_object` does not read from the file in the bucket directly, but instead from the content-type that was sent in the request when it was uploaded. This value could be different from the file itself, e.g. we sent a PNG but set the content-type to image/jpeg and the result from `head_object` was image/jpeg. 

### *What changes have we introduced*

We've commented out the content-type validation in the orchestrator for now and will discuss solutions.

For the frontend work that we're about to do, we've changed the policy to accept 50mb and all content-types.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to be addressed after merging this PR? Add them here.
