### PR TITLE
Add mime type print statement from python/magic library

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -74,7 +74,7 @@ def lambda_handler(event, context):
         move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client)
 
     mime = magic.Magic(mime=True)
-    print(mime.from_file(download_path))
+    print(f"MIME TYPE FROM MAGIC {mime.from_file(download_path)}")
 
     move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client)
    

--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -1,6 +1,8 @@
 import json
 import boto3
 import botocore
+import magic
+
 
 def lambda_handler(event, context):
     # Disable SSL for this instance of the client so that when we call 'download_file' then Palo Altos is able to scan the payload for malware
@@ -70,6 +72,9 @@ def lambda_handler(event, context):
         print('An exception occurred: {}'.format(e))
         print("There was an error when attempting to download the file, moving to quarantine")
         move_file_to_quarantine(file_key_name, copy_source_object, bucket_name, s3_client)
+
+    mime = magic.Magic(mime=True)
+    print(mime.from_file(download_path))
 
     move_file_to_clean_and_update_database_document_entity(event, lambda_client, file_key_name, copy_source_object, bucket_name, s3_client)
    


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-417

## Describe this PR

### *What is the problem we're trying to solve*

S3 only reads content-type from the upload request header, so we need a solution that reads the MIME type directly from the file.

### *What changes have we introduced*

We're trying python/magic to see if this works.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
