### PR TITLE
Add tests for  upload via S3 presigned url path

### DIFF
--- a/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
@@ -9,6 +9,8 @@ using DocumentsApi.V1.Infrastructure;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using Newtonsoft.Json;
+using DocumentsApi.V1.Domain;
 
 namespace DocumentsApi.Tests.V1.E2ETests
 {
@@ -97,6 +99,25 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task CreatingUploadPolicyReturnsPolicyForValidDocument()
+        {
+            _document.UploadedAt = null;
+            DatabaseContext.SaveChanges();
+
+            var uri = new Uri($"api/v1/documents/{_document.Id}/upload_policies", UriKind.Relative);
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var policy = JsonConvert.DeserializeObject<S3UploadPolicy>(jsonString);
+
+            response.StatusCode.Should().Be(200);
+            policy.Fields["key"].Should().Be("pre-scan/" + _document.Id.ToString());
+            policy.Fields["acl"].Should().Be("private");
+            policy.Fields["X-Amz-Server-Side-Encryption"].Should().Be("AES256");
+            policy.Fields["X-Amz-Algorithm"].Should().Be("AWS4-HMAC-SHA256");
+            policy.Fields.Should().ContainKeys("bucket", "X-Amz-Credential", "X-Amz-Date", "Policy", "X-Amz-Signature");
         }
     }
 }

--- a/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
@@ -89,5 +89,14 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             response.StatusCode.Should().Be(404);
         }
+
+        [Test]
+        public async Task CreatingUploadPolicyReturns400ForAlreadyUploadedDocument()
+        {
+            var uri = new Uri($"api/v1/documents/{_document.Id}/upload_policies", UriKind.Relative);
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(400);
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/DocumentsTests.cs
@@ -80,5 +80,14 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             response.StatusCode.Should().Be(404);
         }
+
+        [Test]
+        public async Task CreatingUploadPolicyReturns404ForNonExistentDocument()
+        {
+            var uri = new Uri($"api/v1/documents/{Guid.NewGuid()}/upload_policies", UriKind.Relative);
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(404);
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
@@ -62,7 +62,7 @@ namespace DocumentsApi.Tests.V1.UseCase
 
             _documentsGateway.Setup(x => x.FindDocument(document.Id)).Returns(document);
 
-            Func<Task<S3UploadPolicy>> execute = () => _classUnderTest.Execute(document.Id);
+            Func<Task<S3UploadPolicy>> execute = async () => await _classUnderTest.Execute(document.Id).ConfigureAwait(true);
 
             execute.Should().Throw<BadRequestException>().WithMessage($"Document with ID {document.Id} has already been uploaded.");
         }

--- a/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
@@ -28,8 +28,9 @@ namespace DocumentsApi.Tests.V1.UseCase
         [Test]
         public void ThrowsNotFoundErrorWhenDocumentDoesNotExist()
         {
-            Func<Task<S3UploadPolicy>> execute = async () => await _classUnderTest.Execute(Guid.NewGuid()).ConfigureAwait(true);
-            execute.Should().Throw<NotFoundException>();
+            var documentId = Guid.NewGuid();
+            Func<Task<S3UploadPolicy>> execute = async () => await _classUnderTest.Execute(documentId).ConfigureAwait(true);
+            execute.Should().Throw<NotFoundException>().WithMessage($"Cannot find document with ID {documentId}");
         }
 
         [Test]

--- a/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
@@ -51,5 +51,20 @@ namespace DocumentsApi.Tests.V1.UseCase
             _s3Gateway.VerifyAll();
 
         }
+
+        [Test]
+        public void ThrowsABadRequestErrorWhenDocumentAlreadyUploaded()
+        {
+            var document = _fixture.Build<Document>()
+                .With(x => x.FileSize, 1000)
+                .With(x => x.FileType, "txt")
+                .Create();
+
+            _documentsGateway.Setup(x => x.FindDocument(document.Id)).Returns(document);
+
+            Func<Task<S3UploadPolicy>> execute = () => _classUnderTest.Execute(document.Id);
+
+            execute.Should().Throw<BadRequestException>().WithMessage($"Document with ID {document.Id} has already been uploaded.");
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/CreateUploadPolicyUseCaseTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using AutoFixture;
+using DocumentsApi.V1.Boundary.Response.Exceptions;
+using DocumentsApi.V1.Domain;
+using DocumentsApi.V1.Gateways.Interfaces;
+using DocumentsApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace DocumentsApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class CreateUploadPolicyUseCaseTests
+    {
+        private readonly Mock<IS3Gateway> _s3Gateway = new Mock<IS3Gateway>();
+        private readonly Mock<IDocumentsGateway> _documentsGateway = new Mock<IDocumentsGateway>();
+        private CreateUploadPolicyUseCase _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _classUnderTest = new CreateUploadPolicyUseCase(_s3Gateway.Object, _documentsGateway.Object);
+        }
+
+        [Test]
+        public void ThrowsNotFoundErrorWhenDocumentDoesNotExist()
+        {
+            Func<Task<S3UploadPolicy>> execute = async () => await _classUnderTest.Execute(Guid.NewGuid()).ConfigureAwait(true);
+            execute.Should().Throw<NotFoundException>();
+        }
+    }
+}

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-     <Content Include="V1/Node/index.js" CopyToPublishDirectory="PreserveNewest" />
-     <Content Include="V1/Node/node_modules/**" CopyToPublishDirectory="PreserveNewest" />
+     <Content Include="V1/Node/index.js" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+     <Content Include="V1/Node/node_modules/**" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
    </ItemGroup>
 
 </Project>

--- a/DocumentsApi/V1/Gateways/S3Gateway.cs
+++ b/DocumentsApi/V1/Gateways/S3Gateway.cs
@@ -34,7 +34,6 @@ namespace DocumentsApi.V1.Gateways
                Can be removed when presigned post policies are available in .NET
              */
             var policyString = await _nodeJSService.InvokeFromFileAsync<string>("V1/Node/index.js", args: new[] { _options.DocumentsBucketName, "pre-scan/" + document.Id.ToString(), UrlExpirySeconds }).ConfigureAwait(true);
-            Console.WriteLine($"The S3 link is: {policyString}");
             return JsonConvert.DeserializeObject<S3UploadPolicy>(policyString);
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-611

## Describe this PR

### *What is the problem we're trying to solve*

The upload path for using a presigned url from S3 is working, we just need to add in the unit tests at the gateway and use case level, and E2E tests at the controller level.

### *What changes have we introduced*

Added in the tests and made sure that the Node files were copied to the Output directory, as the final E2E test was failing because index.js was not available in the container or locally.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

None, onto the download path after this!
