### PR TITLE
Add shell=True to subprocess argument to invoke system shell

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -69,9 +69,9 @@ def lambda_handler(event, context):
         print("s3_client.download_file", bucket_name, file_key_name, download_path)
         s3_client_no_ssl.download_file(bucket_name, file_key_name, download_path)
 
-        mimetype_little_i = subprocess.check_output(f"file -i {download_path}")
-        mimetype_big_i = subprocess.check_output(f"file -I {download_path}")
-        mimetype = subprocess.check_output(f"file --mime {download_path}")
+        mimetype_little_i = subprocess.check_output(f"file -i {download_path}", shell=True)
+        mimetype_big_i = subprocess.check_output(f"file -I {download_path}", shell=True)
+        mimetype = subprocess.check_output(f"file --mime {download_path}", shell=True)
         print(f"*********** Mime type with -i (Linux command) {mimetype_little_i}")
         print(f"*********** Mime type with -I {mimetype_big_i}")
         print(f"*********** Mime type with --mime {mimetype}")


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-587

## Describe this PR

### *What is the problem we're trying to solve*

We would like to print the MIME type of a file in the Python script by using shell/system command `file`

### *What changes have we introduced*

Adding `shell=True` to make the command run in the shell.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
