### PR TITLE
Add check for bash location using os library

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -2,6 +2,7 @@ import json
 import boto3
 import botocore
 import subprocess
+import os
 # import magic
 
 
@@ -69,12 +70,15 @@ def lambda_handler(event, context):
     print("s3_client.download_file", bucket_name, file_key_name, download_path)
     s3_client_no_ssl.download_file(bucket_name, file_key_name, download_path)
 
-    mimetype_little_i = subprocess.Popen(['/bin/bash', '-c', f"file -i {download_path}"])
-    mimetype_big_i = subprocess.Popen(['/bin/bash', '-c', f"file -I {download_path}"])
-    mimetype = subprocess.Popen(['/bin/bash', '-c', f"file --mime {download_path}"])
-    print(f"*********** Mime type with -i (Linux command) {mimetype_little_i}")
-    print(f"*********** Mime type with -I {mimetype_big_i}")
-    print(f"*********** Mime type with --mime {mimetype}")
+    stream = os.popen('which bash')
+    bash_location = stream.read()
+    print(f"*********** bash location from os: {bash_location}")
+
+    check_output_command = subprocess.check_output([f"{bash_location}", '-c', f"file -I {download_path}"])
+    print(f"*********** output from check_output mime type command: {check_output_command}")
+
+    popen_command = subprocess.Popen([f"{bash_location}", '-c', f"file -I {download_path}"])
+    print(f"*********** output from Popen command: {popen_command}")
 
     # except Exception as e:
     #     print('An exception occurred: {}'.format(e))


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-649

## Describe this PR

### *What is the problem we're trying to solve*

We're having issues running a bash command from the Python script, because the command for `file` cannot be found. We think it's because the operating system (Amazon Linux 2) in the lambda is not using the bash interpreter to run the command.

### *What changes have we introduced*

Hopefully, by using the os library, we can run `which` to find the correct location of the interpreter (because bash is included in AL2), using its default shell interpreter (/bin/sh).

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
