### PR TITLE
Add CORS configuration in serverless

### DIFF
--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -30,6 +30,12 @@ provider:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      corsConfiguration:
+        CorsRules:
+          - AllowedMethods:
+              - GET
+              - POST
+            AllowedOrigins: ${self:custom.corsDomains.${self:provider.stage}}
 
 package:
   artifact: ./bin/release/netcoreapp3.1/documents-api.zip


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-611

## Describe this PR

Add CORS configuration to be able to use the S3 pre-signed URL for the upload