### PR TITLE
Amend CreateClaimAndUploadPolicy endpoint and add test

### DIFF
--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -201,9 +201,33 @@ namespace DocumentsApi.Tests.V1.E2ETests
         }
 
         [Test]
+        public async Task ClaimAndS3UploadRequestReturnsUploadPolicy()
+        {
+            var uri = new Uri($"api/v1/claims/claim_and_upload_policy", UriKind.Relative);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
+            var formattedValidUntil = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(4));
+
+            string body = "{" +
+                "\"serviceAreaCreatedBy\": \"development-team-staging\"," +
+                "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
+                "\"apiCreatedBy\": \"some-api\"," +
+                $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
+                $"\"validUntil\": {formattedValidUntil}" +
+                "}";
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(uri, jsonString);
+            var readResponse = await response.Content.ReadAsStringAsync();
+            var responseAsObject = JsonConvert.DeserializeObject<ClaimAndS3UploadPolicyResponse>(readResponse);
+
+            response.StatusCode.Should().Be(201);
+            responseAsObject.S3UploadPolicy.Url.Should().NotBeNull();
+        }
+
+        [Test]
         public async Task ClaimAndS3UploadRequestReturnsBadRequestWithInvalidParams()
         {
-            var uri = new Uri($"api/v1/claims/claim_and_document", UriKind.Relative);
+            var uri = new Uri($"api/v1/claims/claim_and_upload_policy", UriKind.Relative);
             var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
             var formattedValidUntil = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(4));
 
@@ -212,7 +236,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
                 "\"apiCreatedBy\": " +
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
-                $"\"validUntil\": {formattedValidUntil}," +
+                $"\"validUntil\": {formattedValidUntil}" +
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");

--- a/DocumentsApi/V1/Controllers/ClaimsController.cs
+++ b/DocumentsApi/V1/Controllers/ClaimsController.cs
@@ -60,34 +60,23 @@ namespace DocumentsApi.V1.Controllers
         }
 
         /// <summary>
-        /// Creates a new claim and uploads a document
+        /// Creates a new claim and returns an upload policy from S3
         /// </summary>
-        /// <response code="201">Claim created and document uploaded</response>
+        /// <response code="201">Claim created and upload policy returned</response>
         /// <response code="400">Request contains invalid parameters</response>
-        /// <response code="400">A document has already been uploaded</response>
         /// <response code="401">Request lacks valid API token</response>
-        /// <response code="404">Document not found</response>
-        /// <response code="500">Document upload exception</response>
         [HttpPost]
-        [Route("claim_and_document")]
-        public async Task<IActionResult> CreateClaimAndUploadDocument(ClaimRequest request)
+        [Route("claim_and_upload_policy")]
+        public async Task<IActionResult> CreateClaimAndUploadPolicy(ClaimRequest request)
         {
             try
             {
-                var result = await _createClaimAndS3UploadPolicyUseCase.ExecuteAsync(request).ConfigureAwait(true);
-                return Created(new Uri($"/claim_and_document/{result.ClaimId}", UriKind.Relative), result);
-            }
-            catch (NotFoundException ex)
-            {
-                return NotFound(ex.Message);
+                var result = await _createClaimAndS3UploadPolicyUseCase.ExecuteAsync(request);
+                return Created(new Uri($"/claim_and_upload_policy/{result.ClaimId}", UriKind.Relative), result);
             }
             catch (BadRequestException ex)
             {
                 return BadRequest(ex.Message);
-            }
-            catch (DocumentUploadException e)
-            {
-                return StatusCode(500, e.Message);
             }
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

Legacy work from https://hackney.atlassian.net/browse/DOC-675

## Describe this PR

### *What is the problem we're trying to solve*

We've updated the behaviour of CreateClaimAndUploadPolicy endpoint, we just need to make sure that the documentation, endpoint makes sense and the happy path is covered by a test.

### *What changes have we introduced*

- Swagger comments updated
- endpoint updated
- existing tests updated
- new test for happy path added

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

After an engineering team discussion, we did identify that 500 errors are not being handled correctly. We're raising a bug ticket for this to add a global 500 catch.
