### PR TITLE
'Add heif to accepted mime types'

### DIFF
--- a/DocumentsApi/python/lambda-orchestrator.py
+++ b/DocumentsApi/python/lambda-orchestrator.py
@@ -20,6 +20,7 @@ accepted_mime_types = [
     'image/bmp', #.bmp
     'image/gif', #.gif
     'image/heic', #.heic
+    'image/heif', #.heif
     'image/jpeg', #.jpeg or .jpg
     'image/png', #.png
     'text/plain', #.txt


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1101

## Describe this PR

Add heif file type to accepted mime types.

### *What is the problem we're trying to solve*

During testing of  https://hackney.atlassian.net/browse/DOC-1007
We noticed some heic files were not appearing on the document submission page. 
On investigation, we found that the hief file types were uploaded to the quarantine folder in the S3 bucket. On checking the code for the quarantine settings, the condition set was that if the mime types were not listed in accepted types, the file would go to quarantine. 

### *What changes have we introduced*

Add heif file type to accepted mime types in DocumentsApi/python/lambda-orchestrator.py

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
Test if the conversion works in staging.
