### PR TITLE
Add targetId and DocumentName to ClaimRequest

### DIFF
--- a/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
@@ -9,5 +9,7 @@ namespace DocumentsApi.V1.Boundary.Request
         public string ApiCreatedBy { get; set; }
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
+        public Guid? TargetId { get; set; }
+        public string DocumentName { get; set; }
     }
 }

--- a/DocumentsApi/V1/Domain/Document.cs
+++ b/DocumentsApi/V1/Domain/Document.cs
@@ -12,5 +12,12 @@ namespace DocumentsApi.V1.Domain
         public DateTime? UploadedAt { get; set; }
 
         public bool Uploaded => UploadedAt != null;
+
+        public Document(){}
+
+        public Document (string name)
+        {
+            this.Name = name;
+        }
     }
 }

--- a/DocumentsApi/V1/Domain/Document.cs
+++ b/DocumentsApi/V1/Domain/Document.cs
@@ -13,9 +13,9 @@ namespace DocumentsApi.V1.Domain
 
         public bool Uploaded => UploadedAt != null;
 
-        public Document(){}
+        public Document() { }
 
-        public Document (string name)
+        public Document(string name)
         {
             this.Name = name;
         }

--- a/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
@@ -41,6 +41,19 @@ namespace DocumentsApi.V1.UseCase
 
         private static Claim BuildClaimRequest(ClaimRequest request)
         {
+            if (!String.IsNullOrEmpty(request.DocumentName))
+            {
+                return new Claim
+                {
+                    ApiCreatedBy = request.ApiCreatedBy,
+                    ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
+                    UserCreatedBy = request.UserCreatedBy,
+                    RetentionExpiresAt = request.RetentionExpiresAt,
+                    ValidUntil = request.ValidUntil,
+                    TargetId = request.TargetId,
+                    Document = new Document(request.DocumentName)
+                };
+            }
             return new Claim
             {
                 ApiCreatedBy = request.ApiCreatedBy,
@@ -48,6 +61,7 @@ namespace DocumentsApi.V1.UseCase
                 UserCreatedBy = request.UserCreatedBy,
                 RetentionExpiresAt = request.RetentionExpiresAt,
                 ValidUntil = request.ValidUntil,
+                TargetId = request.TargetId,
                 // TODO: Support creating claims for existing documents
                 Document = new Document()
             };


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1134

## Describe this PR

### *What changes have we introduced*

Added the ability to specify a target ID and a name for the document when making a request to create a claim.

- Updated `ClaimRequest` to include `TargetId` and `DocumentName`
- Updated `CreateClaimUseCase` to build a new claim containing `DocumentName` or not based on the existence of the `DocumentName` parameter on the `ClaimRequest`
- Added a constructor to the `Document` class to be able to specify the `Name` of the new documented created

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

The next step is to create the endpoint that allows retrieving multiple claims containing the `TargetId` provided in the request.
