### PR TITLE
Add authorization using google groups to the endpoint to get claims by target ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,8 +204,10 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       # Build & Test
-      - check-code-formatting
-      - build-and-test
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context: api-nuget-token-context
 
       # Staging deploy
       - assume-role-staging:
@@ -220,6 +222,7 @@ workflows:
           requires:
             - assume-role-staging
       - deploy-to-staging:
+          context: api-nuget-token-context
           requires:
             - migrate-database-staging
 
@@ -236,6 +239,7 @@ workflows:
           requires:
             - assume-role-production
       - deploy-to-production:
+          context: api-nuget-token-context
           requires:
             - migrate-database-production
       - publish-to-swaggerhub:

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ S3_API_ENDPOINT=http://localhost:5555
 BUCKET_NAME=testBucketName
 AWS_ACCESS_KEY_ID=remote-identity
 AWS_SECRET_ACCESS_KEY=remote-credential
+LBHPACKAGESTOKEN=token
+ALLOWED_GOOGLE_GROUPS=allowed-google-groups

--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,4 @@ S3_API_ENDPOINT=http://localhost:5555
 BUCKET_NAME=testBucketName
 AWS_ACCESS_KEY_ID=remote-identity
 AWS_SECRET_ACCESS_KEY=remote-credential
-LBHPACKAGESTOKEN=token
-ALLOWED_GOOGLE_GROUPS=allowed-google-groups
+GET_CLAIMS_ALLOWED_GOOGLE_GROUPS=allowed-google-groups

--- a/DocumentsApi.Tests/Dockerfile
+++ b/DocumentsApi.Tests/Dockerfile
@@ -3,6 +3,9 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
+ARG LBHPACKAGESTOKEN
+ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
+
 RUN apt-get update \
      && apt-get install curl gnupg -yq \
      && curl -sL https://deb.nodesource.com/setup_14.x | bash \
@@ -14,6 +17,7 @@ WORKDIR /app
 COPY ./DocumentsApi.sln ./
 COPY ./DocumentsApi/DocumentsApi.csproj ./DocumentsApi/
 COPY ./DocumentsApi.Tests/DocumentsApi.Tests.csproj ./DocumentsApi.Tests/
+COPY ./NuGet.Config /root/.nuget/NuGet/NuGet.Config
 
 RUN dotnet restore ./DocumentsApi/DocumentsApi.csproj
 RUN dotnet restore ./DocumentsApi.Tests/DocumentsApi.Tests.csproj

--- a/DocumentsApi.Tests/DocumentsApi.Tests.csproj
+++ b/DocumentsApi.Tests/DocumentsApi.Tests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="AutoFixture" Version="4.14.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
+++ b/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using DocumentsApi.V1.Authorization;
+using FluentAssertions;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+
+namespace DeveloperHubAPI.Tests.V1.Authorization
+{
+    [TestFixture]
+    public class AuthoriseByGroupsTests
+    {
+        TokenGroupsFilter _classUnderTest;
+        Mock<IHttpContextWrapper> _mockContextWrapper;
+        Mock<ITokenFactory> _mockTokenFactory;
+        private string[] _requiredGoogleGroups;
+        private static Fixture _fixture => new Fixture();
+
+        [SetUp]
+        public void Init()
+        {
+            _mockContextWrapper = new Mock<IHttpContextWrapper>();
+            _mockTokenFactory = new Mock<ITokenFactory>();
+            _requiredGoogleGroups = new string[] { "test_group_name", "some-other-group" };
+
+            Environment.SetEnvironmentVariable("groups", string.Join(",", _requiredGoogleGroups));
+
+            _classUnderTest = new TokenGroupsFilter(_mockContextWrapper.Object, _mockTokenFactory.Object, "groups");
+        }
+
+        [Test]
+        public void ConstructorThrowsErrorIfGroupsEnvVariableIsNull()
+        {
+            var incorrectEnvVariable = "var";
+
+            Func<TokenGroupsFilter> func = () => new TokenGroupsFilter(_mockContextWrapper.Object, _mockTokenFactory.Object, incorrectEnvVariable);
+
+            func.Should().Throw<EnvironmentVariableNullException>().WithMessage($"Cannot resolve {incorrectEnvVariable} environment variable.");
+        }
+
+        private (AuthorizationFilterContext, HeaderDictionary) SetUpMockContextAndHeaders()
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            var actionContext = new ActionContext(mockHttpContext.Object,
+                                                  new Microsoft.AspNetCore.Routing.RouteData(),
+                                                  new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor());
+            var context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+
+            var requestHeaders = new HeaderDictionary(new Dictionary<string, StringValues> { { "Authorization", "abc" } });
+            _mockContextWrapper.Setup(x => x.GetContextRequestHeaders(context.HttpContext)).Returns(requestHeaders);
+
+            return (context, requestHeaders);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsUnauthorizedIfTokenIsNull()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) null);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeOfType(typeof(UnauthorizedObjectResult));
+            (context.Result as UnauthorizedObjectResult).Value.Should().Be("User  is not authorized to access this endpoint.");
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsUnauthorizedIfTokenDoesNotContainRequiredGoogleGroups()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            var userToken = _fixture.Build<Token>().With(x => x.Groups, new string[] { "not one of the allowed groups" }).Create();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) userToken);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeOfType(typeof(UnauthorizedObjectResult));
+            (context.Result as UnauthorizedObjectResult).Value.Should().Be($"User {userToken.Name} is not authorized to access this endpoint.");
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+        [Test]
+        public void OnAuthorizationResultIsNullIfTokenContainsOneOfTheRequiredGoogleGroups()
+        {
+            // Arrange
+            (var context, var requestHeaders) = SetUpMockContextAndHeaders();
+            var userToken = _fixture.Build<Token>().With(x => x.Groups, new string[] { "test_group_name" }).Create();
+            _mockTokenFactory.Setup(x => x.Create(requestHeaders, "Authorization")).Returns((Token) userToken);
+            // Act
+            _classUnderTest.OnAuthorization(context);
+            // Assert
+            context.Result.Should().BeNull();
+            _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
+        }
+
+    }
+}

--- a/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
+++ b/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
@@ -36,27 +36,13 @@ namespace DeveloperHubAPI.Tests.V1.Authorization
         }
 
         [Test]
-        public void ConstructorThrowsErrorIfGroupsEnvVariableIsNull()
+        public void ConstructorThrowsErrorIfGroupsEnvVariableIsEmpty()
         {
-            var incorrectEnvVariable = "var";
+            var incorrectEnvVariable = "";
 
             Func<TokenGroupsFilter> func = () => new TokenGroupsFilter(_mockContextWrapper.Object, _mockTokenFactory.Object, incorrectEnvVariable);
 
             func.Should().Throw<EnvironmentVariableNullException>().WithMessage($"Cannot resolve {incorrectEnvVariable} environment variable.");
-        }
-
-        private (AuthorizationFilterContext, HeaderDictionary) SetUpMockContextAndHeaders()
-        {
-            var mockHttpContext = new Mock<HttpContext>();
-            var actionContext = new ActionContext(mockHttpContext.Object,
-                                                  new Microsoft.AspNetCore.Routing.RouteData(),
-                                                  new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor());
-            var context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
-
-            var requestHeaders = new HeaderDictionary(new Dictionary<string, StringValues> { { "Authorization", "abc" } });
-            _mockContextWrapper.Setup(x => x.GetContextRequestHeaders(context.HttpContext)).Returns(requestHeaders);
-
-            return (context, requestHeaders);
         }
 
         [Test]
@@ -102,5 +88,18 @@ namespace DeveloperHubAPI.Tests.V1.Authorization
             _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
         }
 
+        private (AuthorizationFilterContext, HeaderDictionary) SetUpMockContextAndHeaders()
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            var actionContext = new ActionContext(mockHttpContext.Object,
+                                                  new Microsoft.AspNetCore.Routing.RouteData(),
+                                                  new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor());
+            var context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+
+            var requestHeaders = new HeaderDictionary(new Dictionary<string, StringValues> { { "Authorization", "abc" } });
+            _mockContextWrapper.Setup(x => x.GetContextRequestHeaders(context.HttpContext)).Returns(requestHeaders);
+
+            return (context, requestHeaders);
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
+++ b/DocumentsApi.Tests/V1/Authorization/AuthorizeByGroupsTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Primitives;
 using Moq;
 using NUnit.Framework;
 
-namespace DeveloperHubAPI.Tests.V1.Authorization
+namespace DocumentsApi.Tests.V1.Authorization
 {
     [TestFixture]
     public class AuthoriseByGroupsTests
@@ -55,7 +55,7 @@ namespace DeveloperHubAPI.Tests.V1.Authorization
             _classUnderTest.OnAuthorization(context);
             // Assert
             context.Result.Should().BeOfType(typeof(UnauthorizedObjectResult));
-            (context.Result as UnauthorizedObjectResult).Value.Should().Be("User  is not authorized to access this endpoint.");
+            (context.Result as UnauthorizedObjectResult).Value.Should().Be("An authorization token was not provided.");
             _mockTokenFactory.Verify(x => x.Create(requestHeaders, "Authorization"), Times.Once);
         }
 

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -393,5 +393,17 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             response.StatusCode.Should().Be(400);
         }
+
+        [Test]
+        public async Task Returns401WhenNotAuthorizedToGetClaimsByTargetId()
+        {
+            var targetId = "c585f2d3-69c8-4a5e-b74f-c0570665c2d8";
+
+            var uri = new Uri($"api/v1/claims?targetId={targetId}", UriKind.Relative);
+
+            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(401);
+        }
     }
 }

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DocumentsApi.V1.Boundary.Response;
 using DocumentsApi.V1.Factories;
+using DocumentsApi.Tests.V1.E2ETests.Constants;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -344,6 +345,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             var uri = new Uri($"api/v1/claims?targetId={claim.TargetId}", UriKind.Relative);
+            Client.DefaultRequestHeaders.Add("Authorization", TestToken.Value);
+
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
             var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
             var result = JsonConvert.DeserializeObject<Dictionary<string, List<ClaimResponse>>>(jsonString);
@@ -384,6 +387,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var invalidTargetId = "abc";
 
             var uri = new Uri($"api/v1/claims?targetId={invalidTargetId}", UriKind.Relative);
+            Client.DefaultRequestHeaders.Add("Authorization", TestToken.Value);
 
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 

--- a/DocumentsApi.Tests/V1/E2ETests/Constants.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/Constants.cs
@@ -1,0 +1,9 @@
+namespace DocumentsApi.Tests.V1.E2ETests.Constants
+{
+    public static class TestToken
+    {
+        public const string Value = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
+        public const string UserName = "Tester";
+        public const string UserEmail = "e2e-testing@development.com";
+    }
+}

--- a/DocumentsApi.Tests/compose.yml
+++ b/DocumentsApi.Tests/compose.yml
@@ -3,12 +3,15 @@ services:
     build:
       context: ../
       dockerfile: ./DocumentsApi.Tests/Dockerfile
+      args:
+        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
     environment:
       CONNECTION_STRING: Host=db;Port=5432;Database=documents_api;Username=postgres;Password=mypassword
       BUCKET_NAME: testBucketName
       S3_API_ENDPOINT: http://s3-mock:80
       AWS_ACCESS_KEY_ID: remote-identity
       AWS_SECRET_ACCESS_KEY: remote-credential
+      ALLOWED_GOOGLE_GROUPS: e2e-testing
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/DocumentsApi.Tests/compose.yml
+++ b/DocumentsApi.Tests/compose.yml
@@ -11,7 +11,7 @@ services:
       S3_API_ENDPOINT: http://s3-mock:80
       AWS_ACCESS_KEY_ID: remote-identity
       AWS_SECRET_ACCESS_KEY: remote-credential
-      ALLOWED_GOOGLE_GROUPS: e2e-testing
+      GET_CLAIMS_ALLOWED_GOOGLE_GROUPS: e2e-testing
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/DocumentsApi/Dockerfile
+++ b/DocumentsApi/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
+ARG LBHPACKAGESTOKEN
+ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
+
 RUN apt-get update \
      && apt-get install curl gnupg -yq \
      && curl -sL https://deb.nodesource.com/setup_14.x | bash \
@@ -9,6 +12,7 @@ WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY ./DocumentsApi/*.csproj ./
+COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 RUN dotnet restore
 
 # Copy everything else and build

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.7.10" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
@@ -35,6 +36,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
     <PackageReference Include="dotenv.net" Version="2.1.1" />
+    <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.7.10" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
+    <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
@@ -36,7 +37,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
     <PackageReference Include="dotenv.net" Version="2.1.1" />
-    <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocumentsApi/Startup.cs
+++ b/DocumentsApi/Startup.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
 
 namespace DocumentsApi
 {
@@ -125,6 +127,9 @@ namespace DocumentsApi
             {
                 Console.WriteLine("LOADED ENVIRONMENT FROM .env");
             }
+
+            services.AddTokenFactory()
+                .AddHttpContextWrapper();
 
             ServiceConfigurator.ConfigureServices(services);
         }

--- a/DocumentsApi/V1/Authorization/AuthorizeByGroups.cs
+++ b/DocumentsApi/V1/Authorization/AuthorizeByGroups.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DocumentsApi.V1.Authorization
+{
+    public class AuthorizeByGroups : TypeFilterAttribute
+    {
+        /// <summary>
+        /// Authorise this endpoint using permitted groups
+        /// </summary>
+        /// <param name="permittedGroupsVariable">
+        /// The name of the environment variable that stores the permitted groups for the endpoint
+        /// </param>
+        public AuthorizeByGroups(string permittedGroupsVariable)
+            : base(typeof(TokenGroupsFilter))
+        {
+            Arguments = new object[] { permittedGroupsVariable };
+        }
+    }
+
+    public class TokenGroupsFilter : IAuthorizationFilter
+    {
+        private readonly string[] _requiredGoogleGroups;
+        private readonly ITokenFactory _tokenFactory;
+        private readonly IHttpContextWrapper _contextWrapper;
+
+        public TokenGroupsFilter(IHttpContextWrapper contextWrapper, ITokenFactory tokenFactory, string permittedGroupsVariable)
+        {
+            _contextWrapper = contextWrapper;
+            _tokenFactory = tokenFactory;
+
+            var requiredGooglepermittedGroupsVariable = Environment.GetEnvironmentVariable(permittedGroupsVariable);
+            if (requiredGooglepermittedGroupsVariable is null) throw new EnvironmentVariableNullException(permittedGroupsVariable);
+
+            _requiredGoogleGroups = requiredGooglepermittedGroupsVariable.Split(','); // Note: Env variable must not have spaces after commas
+        }
+
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            var token = _tokenFactory.Create(_contextWrapper.GetContextRequestHeaders(context.HttpContext));
+            if (token is null || !token.Groups.Any(g => _requiredGoogleGroups.Contains(g)))
+            {
+                context.Result = new UnauthorizedObjectResult($"User {token?.Name} is not authorized to access this endpoint.");
+            }
+        }
+    }
+}

--- a/DocumentsApi/V1/Authorization/AuthorizeByGroups.cs
+++ b/DocumentsApi/V1/Authorization/AuthorizeByGroups.cs
@@ -42,7 +42,12 @@ namespace DocumentsApi.V1.Authorization
         public void OnAuthorization(AuthorizationFilterContext context)
         {
             var token = _tokenFactory.Create(_contextWrapper.GetContextRequestHeaders(context.HttpContext));
-            if (token is null || !token.Groups.Any(g => _requiredGoogleGroups.Contains(g)))
+            if (token is null)
+            {
+                context.Result = new UnauthorizedObjectResult($"An authorization token was not provided.");
+            }
+
+            if (token != null && !token.Groups.Any(g => _requiredGoogleGroups.Contains(g)))
             {
                 context.Result = new UnauthorizedObjectResult($"User {token?.Name} is not authorized to access this endpoint.");
             }

--- a/DocumentsApi/V1/Authorization/EnvironmentVariableNullException.cs
+++ b/DocumentsApi/V1/Authorization/EnvironmentVariableNullException.cs
@@ -1,0 +1,8 @@
+namespace DocumentsApi.V1.Authorization
+{
+    public class EnvironmentVariableNullException : System.Exception
+    {
+        public EnvironmentVariableNullException(string variableName) : base($"Cannot resolve {variableName} environment variable.") { }
+
+    }
+}

--- a/DocumentsApi/V1/Controllers/ClaimsController.cs
+++ b/DocumentsApi/V1/Controllers/ClaimsController.cs
@@ -189,7 +189,7 @@ namespace DocumentsApi.V1.Controllers
         /// <response code="400">Request contains invalid parameters</response>
         /// <response code="401">Request lacks valid API token</response>
         [HttpGet]
-        [AuthorizeByGroups("ALLOWED_GOOGLE_GROUPS")]
+        [AuthorizeByGroups("GET_CLAIMS_ALLOWED_GOOGLE_GROUPS")]
         public IActionResult GetClaimsByTargetId([FromQuery] Guid targetId)
         {
             try

--- a/DocumentsApi/V1/Controllers/ClaimsController.cs
+++ b/DocumentsApi/V1/Controllers/ClaimsController.cs
@@ -6,6 +6,7 @@ using DocumentsApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Amazon.S3;
 using System.Threading.Tasks;
+using DocumentsApi.V1.Authorization;
 
 namespace DocumentsApi.V1.Controllers
 {
@@ -188,6 +189,7 @@ namespace DocumentsApi.V1.Controllers
         /// <response code="400">Request contains invalid parameters</response>
         /// <response code="401">Request lacks valid API token</response>
         [HttpGet]
+        [AuthorizeByGroups("ALLOWED_GOOGLE_GROUPS")]
         public IActionResult GetClaimsByTargetId([FromQuery] Guid targetId)
         {
             try

--- a/DocumentsApi/compose.yml
+++ b/DocumentsApi/compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../
       dockerfile: ./DocumentsApi/Dockerfile
+      args:
+        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
     env_file: ../.env
     environment:
       CONNECTION_STRING: Host=db;Port=5432;Database=documents_api;Username=postgres;Password=mypassword
@@ -30,7 +32,7 @@ services:
     ports:
       - "3004:5432"
     volumes:
-        - ../database/data:/var/lib/postgresql/data
+      - ../database/data:/var/lib/postgresql/data
 
   s3-mock:
     image: andrewgaul/s3proxy

--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -17,6 +17,7 @@ provider:
   environment:
     CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password}
     BUCKET_NAME: document-evidence-store-${self:provider.stage}-bucket
+    ALLOWED_GOOGLE_GROUPS: /documents-api/${self:provider.stage}/get/claims/allowed-google-groups
   s3:
     documentsBucket:
       accessControl: Private

--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -17,7 +17,7 @@ provider:
   environment:
     CONNECTION_STRING: Host=${ssm:/documents-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/documents-api/${self:provider.stage}/postgres-port};Database=${ssm:/documents-api/${self:provider.stage}/postgres-database};Username=${ssm:/documents-api/${self:provider.stage}/postgres-username};Password=${ssm:/documents-api/${self:provider.stage}/postgres-password}
     BUCKET_NAME: document-evidence-store-${self:provider.stage}-bucket
-    ALLOWED_GOOGLE_GROUPS: /documents-api/${self:provider.stage}/get/claims/allowed-google-groups
+    GET_CLAIMS_ALLOWED_GOOGLE_GROUPS: /documents-api/${self:provider.stage}/get/claims/allowed-google-groups
   s3:
     documentsBucket:
       accessControl: Private

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,19 @@
+<configuration>
+
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github-hackney" value="https://nuget.pkg.github.com/LBHackney-IT/index.json" />
+  </packageSources>
+
+  <packageSourceCredentials>
+    <github-hackney>
+      <add key="Username" value="PublicToken" />
+      <add key="ClearTextPassword" value= "%LBHPACKAGESTOKEN%" />
+    </github-hackney>
+  </packageSourceCredentials>
+
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+
+</configuration>

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Documents API is a Platform API to securely and easily store and retrieve docume
 -   .NET Core v3.1 as a web framework.
 -   nUnit v3.11 as a test framework.
 
-
 ## What does it do?
 
 [**🚀 Swagger**](https://app.swaggerhub.com/apis-docs/Hackney/documents-api/1.0.0) ([Edit it here](https://app.swaggerhub.com/apis/Hackney/documents-api/1.0.0))
-
 
 ## Dependencies
 
@@ -29,11 +27,26 @@ Documents API is a Platform API to securely and easily store and retrieve docume
 
 In order to run the API locally, you will first need to copy the environment variables in the [.env.example](.env.example) file and save them to a new file called `.env` in the root of the project (same place as `.env.example`). This file should not be tracked by git, as it has been added to the `.gitignore`, so please do check that this is the case.
 
+You will also need to seprately set up `LBHPACKAGESTOKEN` env var (used to access the [lbh-core](https://github.com/LBHackney-IT/lbh-core) library) in your terminal profile or in every terminal window. To do that for PowerShell you can use this command:
+
+```
+[System.Environment]::SetEnvironmentVariable('LBHPACKAGESTOKEN','<TOKEN VALUE GOES HERE>',[System.EnvironmentVariableTarget]::User)
+```
+
+and for Linux/Mac you can use this command
+
+```
+export LBHPACKAGESTOKEN=<TOKEN VALUE GOES HERE>
+```
+
+The values for all the env vars can be found in the Parameter Store, in `Document-Evidence-Store-Staging` and `Document-Evidence-Store-Production` AWS accounts.
+
 ### 2. Set up containers
 
 Next step, to set up the local Documents API container, `cd` into the root of the project
 (same place as the Makefile) and run `make serve-local`. This will set up the database container,
 S3 proxy, run an automatic migration and stand up the API container. There are other Make recipes in the file;
+
 ```
 # build the image and start the db, s3 proxy, migration and API containers
 $ make serve-local
@@ -45,9 +58,9 @@ $ make build-local
 $ make start-local
 ```
 
-* The API will run on `http://localhost:3003`
-* The database will run on `http://localhost:3004`
-* The S3 proxy will run on `http://localhost:5555`
+-   The API will run on `http://localhost:3003`
+-   The database will run on `http://localhost:3004`
+-   The S3 proxy will run on `http://localhost:5555`
 
 ### 3. Testing
 
@@ -58,16 +71,18 @@ There are two ways to test the application:
 
 The simplest and most reliable way is running the tests in the container. You can do this by running `make serve-test`,
 which will build the images and run the containers. There are other Make recipes in the file;
+
 ```
 # build the image and start the db, s3 proxy, migration and test containers
 $ make serve-test
 
 # build the images
-$ make build-test 
+$ make build-test
 
 # start the db, s3 proxy, migration and test containers
 $ make start-test
 ```
+
 However, you might want to run the tests locally, in order to debug them through your IDE. The codebase is also set up to allow this.
 All you need to do is to make sure that your `CONNECTION_STRING` envar in `.env` is the same as the one in `.env.example`.
 
@@ -98,7 +113,7 @@ This application contains two lambda functions — an API, and a function which 
 To test the S3 Lambda function with the staging AWS account, follow these steps:
 
 1. Install [AWS lambda test tool](e18ebff8-2a46-4ee3-8d27-c36706ac006f): `dotnet tool install -g Amazon.Lambda.TestTool-3.1`
-2. Create a document in the staging S3 bucket with the key ``e18ebff8-2a46-4ee3-8d27-c36706ac006f``
+2. Create a document in the staging S3 bucket with the key `e18ebff8-2a46-4ee3-8d27-c36706ac006f`
 3. Create the equivalent record in your local database:
     ```shell script
     psql --database documents_api -f database/s3-test-seed.sql
@@ -122,9 +137,9 @@ We use a pull request workflow, where changes are made on a branch and approved 
 Then we have an automated six step deployment process, which runs in CircleCI.
 
 1. Automated tests (nUnit) are run to ensure the release is of good quality.
-4. The application is deployed to staging automatically.
-5. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
-6. The application is deployed to production.
+2. The application is deployed to staging automatically.
+3. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
+4. The application is deployed to production.
 
 Our staging and production environments are hosted by AWS. We would deploy to production per each feature/config merged into `main` branch.
 
@@ -137,9 +152,11 @@ make lint
 ```
 
 Otherwise your PR will automatically fail the CircleCI checks. This Make recipe will install the `dotnet format` tool for you, so from then on, you can just run:
+
 ```sh
 dotnet format
 ```
+
 to format your code.
 
 To help with making changes to code easier to understand when being reviewed, we've added a PR template.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Documents API is a Platform API to securely and easily store and retrieve docume
 
 In order to run the API locally, you will first need to copy the environment variables in the [.env.example](.env.example) file and save them to a new file called `.env` in the root of the project (same place as `.env.example`). This file should not be tracked by git, as it has been added to the `.gitignore`, so please do check that this is the case.
 
-You will also need to seprately set up `LBHPACKAGESTOKEN` env var (used to access the [lbh-core](https://github.com/LBHackney-IT/lbh-core) library) in your terminal profile or in every terminal window. To do that for PowerShell you can use this command:
+You will also need to separately set up `LBHPACKAGESTOKEN` env var (used to access the [lbh-core](https://github.com/LBHackney-IT/lbh-core) library) in your terminal profile or in every terminal window. To do that for PowerShell you can use this command:
 
 ```
 [System.Environment]::SetEnvironmentVariable('LBHPACKAGESTOKEN','<TOKEN VALUE GOES HERE>',[System.EnvironmentVariableTarget]::User)

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
+ARG LBHPACKAGESTOKEN
+ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
+
 WORKDIR /app
 
 # Install dotnet-ef globally
@@ -15,6 +18,7 @@ RUN sudo apt-get install net-tools
 
 # Copy csproj and restore as distinct layers
 COPY ./DocumentsApi/*.csproj ./
+COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 RUN dotnet restore
 
 # Copy everything else and build

--- a/database/compose.yml
+++ b/database/compose.yml
@@ -3,7 +3,9 @@ services:
     build:
       context: ../
       dockerfile: ./database/Dockerfile
-    environment: 
+      args:
+        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+    environment:
       - CONNECTION_STRING=Host=db;Port=5432;Database=documents_api;Username=postgres;Password=mypassword
 
   db:
@@ -13,9 +15,9 @@ services:
       POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: documents_api
     expose:
-      - '5432'
+      - "5432"
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U',  'postgres', '-d', 'documents_api']
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "documents_api"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1141

## Describe this PR

### *What changes have we introduced*

Added authorization using google groups to the endpoint used to get claims by target ID.

- The authorization is using the [lbh-core](https://github.com/LBHackney-IT/lbh-core) library
- Added changes to the docker files and docker-compose files to allow the usage of the lbh-core library
- Added NuGet package configuration (which is using a secret token to allow usage)
- Updated tests to contain the authorization header
- Updated the README file with information regarding setting up the new token needed to use the lbh-core library

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly