### PR TITLE
Doc 1185: Add description to document data

### DIFF
--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -51,6 +51,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"id\":\"{document.Id}\"," +
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   "\"name\":\"Some name\"," +
+                                  "\"description\":null," +
                                   "\"fileSize\":0," +
                                   "\"fileType\":null," +
                                   "\"uploadedAt\":null" +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -30,12 +30,13 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
                 $"\"validUntil\": {formattedValidUntil}," +
                 "\"targetId\": \"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
-                "\"documentName\": \"Some name\"" +
+                "\"documentName\": \"Some name\"," +
+                "\"documentDescription\": \"Some description\"" +
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
+            var json = await response.Content.ReadAsStringAsync();
 
             response.StatusCode.Should().Be(201);
 
@@ -51,7 +52,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"id\":\"{document.Id}\"," +
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   "\"name\":\"Some name\"," +
-                                  "\"description\":null," +
+                                  "\"description\":\"Some description\"," +
                                   "\"fileSize\":0," +
                                   "\"fileType\":null," +
                                   "\"uploadedAt\":null" +
@@ -366,7 +367,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"id\":\"{claim.Document.Id}\"," +
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   $"\"name\":\"{claim.Document.Name}\"," +
-                                  $"\"description\":null," +
+                                  $"\"description\":\"{claim.Document.Description}\"," +
                                   $"\"fileSize\":0," +
                                   $"\"fileType\":null," +
                                   $"\"uploadedAt\":null" +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -100,6 +100,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"id\":\"{document.Id}\"," +
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   "\"name\":\"Some name\"," +
+                                  "\"description\":null," +
                                   "\"fileSize\":0," +
                                   "\"fileType\":null," +
                                   "\"uploadedAt\":null" +
@@ -365,6 +366,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"id\":\"{claim.Document.Id}\"," +
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   $"\"name\":\"{claim.Document.Name}\"," +
+                                  $"\"description\":null," +
                                   $"\"fileSize\":0," +
                                   $"\"fileType\":null," +
                                   $"\"uploadedAt\":null" +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -251,14 +251,12 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             var uri = new Uri($"api/v1/claims/claim_and_download_url/${fakeClaimId}", UriKind.Relative);
             var response = await Client.GetAsync(uri);
-            var jsonString = await response.Content.ReadAsStringAsync();
-            var result = JsonConvert.DeserializeObject<ClaimAndPreSignedDownloadUrlResponse>(jsonString);
 
             response.StatusCode.Should().Be(400);
         }
 
         [Test]
-        public async Task ClaimAndS3UploadRequestReturnsUploadPolicy()
+        public async Task ClaimAndS3UploadRequestReturnsUploadPolicyAndClaim()
         {
             var uri = new Uri($"api/v1/claims/claim_and_upload_policy", UriKind.Relative);
             var formattedRetentionExpiresAt = JsonConvert.SerializeObject(DateTime.UtcNow.AddDays(3));
@@ -269,7 +267,9 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "\"userCreatedBy\": \"staff@test.hackney.gov.uk\"," +
                 "\"apiCreatedBy\": \"some-api\"," +
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
-                $"\"validUntil\": {formattedValidUntil}" +
+                $"\"validUntil\": {formattedValidUntil}," +
+                $"\"documentName\": \"some-name\"," +
+                $"\"documentDescription\": \"some-description\"" +
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -278,6 +278,9 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var responseAsObject = JsonConvert.DeserializeObject<ClaimAndS3UploadPolicyResponse>(readResponse);
 
             response.StatusCode.Should().Be(201);
+            responseAsObject.ClaimId.Should().NotBeEmpty();
+            responseAsObject.Document.Name.Should().Be("some-name");
+            responseAsObject.Document.Description.Should().Be("some-description");
             responseAsObject.S3UploadPolicy.Url.Should().NotBeNull();
         }
 

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -268,8 +268,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "\"apiCreatedBy\": \"some-api\"," +
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
                 $"\"validUntil\": {formattedValidUntil}," +
-                $"\"documentName\": \"some-name\"," +
-                $"\"documentDescription\": \"some-description\"" +
+                "\"documentName\": \"some-name\"," +
+                "\"documentDescription\": \"some-description\"" +
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -304,7 +304,6 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             response.StatusCode.Should().Be(400);
         }
-
 
         [Test]
         public async Task ReturnsDownloadUrlWhenClaimIsFound()
@@ -355,7 +354,6 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             var response = await Client.GetAsync(uri);
             var jsonString = await response.Content.ReadAsStringAsync();
-            var result = JsonConvert.DeserializeObject<Dictionary<string, List<ClaimResponse>>>(jsonString);
 
             var formattedCreatedAt = JsonConvert.SerializeObject(claim.CreatedAt);
             var formattedDocumentCreatedAt = JsonConvert.SerializeObject(claim.Document.CreatedAt);
@@ -371,9 +369,9 @@ namespace DocumentsApi.Tests.V1.E2ETests
                                   $"\"createdAt\":{formattedDocumentCreatedAt}," +
                                   $"\"name\":\"{claim.Document.Name}\"," +
                                   $"\"description\":\"{claim.Document.Description}\"," +
-                                  $"\"fileSize\":0," +
-                                  $"\"fileType\":null," +
-                                  $"\"uploadedAt\":null" +
+                                  "\"fileSize\":0," +
+                                  "\"fileType\":null," +
+                                  "\"uploadedAt\":null" +
                               "}," +
                               $"\"serviceAreaCreatedBy\":\"{claim.ServiceAreaCreatedBy}\"," +
                               $"\"userCreatedBy\":\"{claim.UserCreatedBy}\"," +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -84,8 +84,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
+            var json = await response.Content.ReadAsStringAsync();
 
             response.StatusCode.Should().Be(201);
 
@@ -131,7 +131,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                           "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
 
             response.StatusCode.Should().Be(400);
         }
@@ -145,8 +145,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             var uri = new Uri($"api/v1/claims/{claim.Id}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var jsonString = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<ClaimResponse>(jsonString);
 
             response.StatusCode.Should().Be(200);
@@ -159,7 +159,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
         public async Task FindingAnInvalidDocumentReturns404()
         {
             var uri = new Uri($"api/v1/claims/{Guid.NewGuid()}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(404);
         }
@@ -182,12 +182,12 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/claims/{claim.Id}", UriKind.Relative);
 
             // Act
-            var response = await Client.PatchAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PatchAsync(uri, jsonString);
 
             // Assert
             response.StatusCode.Should().Be(200);
 
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var json = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<ClaimResponse>(json);
 
             result.Should().BeEquivalentTo(claim.ToDomain().ToResponse(),
@@ -214,7 +214,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/claims/{claim.Id}", UriKind.Relative);
 
             // Act
-            var response = await Client.PatchAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PatchAsync(uri, jsonString);
 
             // Assert
             response.StatusCode.Should().Be(404);
@@ -232,8 +232,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
             MockS3Client.Setup(x => x.GetPreSignedURL(It.IsAny<GetPreSignedUrlRequest>())).Returns(expectedPreSignedDownloadUrl);
 
             var uri = new Uri($"api/v1/claims/claim_and_download_url/{claim.Id}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var jsonString = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<ClaimAndPreSignedDownloadUrlResponse>(jsonString);
 
             response.StatusCode.Should().Be(200);
@@ -250,8 +250,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var fakeClaimId = Guid.NewGuid();
 
             var uri = new Uri($"api/v1/claims/claim_and_download_url/${fakeClaimId}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var jsonString = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<ClaimAndPreSignedDownloadUrlResponse>(jsonString);
 
             response.StatusCode.Should().Be(400);
@@ -297,7 +297,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
 
             response.StatusCode.Should().Be(400);
         }
@@ -319,7 +319,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             var uri = new Uri($"api/v1/claims/{claimId}/download_links", UriKind.Relative);
 
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(200);
         }
@@ -331,7 +331,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             var uri = new Uri($"api/v1/claims/{nonExistentClaimId}/download_links", UriKind.Relative);
 
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(404);
         }
@@ -350,8 +350,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/claims?targetId={claim.TargetId}", UriKind.Relative);
             Client.DefaultRequestHeaders.Add("Authorization", TestToken.Value);
 
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var jsonString = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<Dictionary<string, List<ClaimResponse>>>(jsonString);
 
             var formattedCreatedAt = JsonConvert.SerializeObject(claim.CreatedAt);
@@ -393,7 +393,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/claims?targetId={invalidTargetId}", UriKind.Relative);
             Client.DefaultRequestHeaders.Add("Authorization", TestToken.Value);
 
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(400);
         }
@@ -405,7 +405,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
 
             var uri = new Uri($"api/v1/claims?targetId={targetId}", UriKind.Relative);
 
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(401);
         }

--- a/DocumentsApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/DocumentsApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -21,6 +21,7 @@ namespace DocumentsApi.Tests.V1.Factories
             domain.Id.Should().Be(entity.Id);
             domain.CreatedAt.Should().Be(entity.CreatedAt);
             domain.Name.Should().Be(entity.Name);
+            domain.Description.Should().Be(entity.Description);
             domain.FileSize.Should().Be(entity.FileSize);
             domain.FileType.Should().Be(entity.FileType);
         }

--- a/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -59,9 +59,9 @@ namespace DocumentsApi.Tests.V1.Factories
             var claim = _fixture.Build<Claim>()
                 .With(x => x.Document, document)
                 .Create();
-            var s3preSignedDownloadUrl = new String("www.awsS3DownloadUrl.com");
+            var s3PreSignedDownloadUrl = new String("www.awsS3DownloadUrl.com");
 
-            var response = claim.ToClaimAndPreSignedDownloadUrlResponse(s3preSignedDownloadUrl);
+            var response = claim.ToClaimAndPreSignedDownloadUrlResponse(s3PreSignedDownloadUrl);
             var expected = new ClaimAndPreSignedDownloadUrlResponse
             {
                 ClaimId = response.ClaimId,
@@ -73,7 +73,7 @@ namespace DocumentsApi.Tests.V1.Factories
                 RetentionExpiresAt = response.RetentionExpiresAt,
                 ValidUntil = response.ValidUntil,
                 TargetId = response.TargetId,
-                PreSignedDownloadUrl = s3preSignedDownloadUrl
+                PreSignedDownloadUrl = s3PreSignedDownloadUrl
             };
 
             response.Should().BeEquivalentTo(expected);

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -140,10 +140,5 @@ namespace DocumentsApi.Tests.V1.Validators
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();
         }
-
-
-
-
-
     }
 }

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -101,5 +101,37 @@ namespace DocumentsApi.Tests.V1.Validators
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();
         }
+        [Test]
+        public void FailsWhenDocumentDescriptionLongerThan1000Characters()
+        {
+            var tooLongDescription = new string('T', 1001);
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.DocumentDescription,tooLongDescription)
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeFalse();
+        }
+
+        [Test]
+        public void AcceptsWhenDocumentDescriptionIsExactly1000Characters()
+        {
+            var validDescription = new string('T', 1000);
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.DocumentDescription,validDescription)
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void FailsWhenDocumentDescriptionShorterThan1Character()
+        {
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.DocumentDescription, "")
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeFalse();
+        }
+
     }
 }

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -12,11 +12,13 @@ namespace DocumentsApi.Tests.V1.Validators
     {
         private Fixture _fixture = new Fixture();
         private ClaimRequestValidator _classUnderTest;
+        private DateTime _validRetentionDate;
 
         [SetUp]
         public void SetUp()
         {
             _classUnderTest = new ClaimRequestValidator();
+            _validRetentionDate = DateTime.UtcNow.AddDays(1);
         }
 
         [TestCase("")]
@@ -75,8 +77,10 @@ namespace DocumentsApi.Tests.V1.Validators
         [Test]
         public void FailsWithDocumentNameLongerThan300Characters()
         {
+            var tooLongName = new string('A', 301);
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.DocumentName, "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec p")
+                .With(x => x.DocumentName, tooLongName)
+                .With(x => x.RetentionExpiresAt, _validRetentionDate)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
@@ -87,26 +91,19 @@ namespace DocumentsApi.Tests.V1.Validators
         {
             var request = _fixture.Build<ClaimRequest>()
                 .With(x => x.DocumentName, "")
+                .With(x => x.RetentionExpiresAt, _validRetentionDate)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
         }
 
         [Test]
-        public void ValidatesAValidRequest()
-        {
-            var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.RetentionExpiresAt, DateTime.UtcNow.AddDays(1))
-                .Create();
-
-            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
-        }
-        [Test]
         public void FailsWhenDocumentDescriptionLongerThan1000Characters()
         {
             var tooLongDescription = new string('T', 1001);
             var request = _fixture.Build<ClaimRequest>()
                 .With(x => x.DocumentDescription, tooLongDescription)
+                .With(x => x.RetentionExpiresAt, _validRetentionDate)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
@@ -116,11 +113,12 @@ namespace DocumentsApi.Tests.V1.Validators
         public void AcceptsWhenDocumentDescriptionIsExactly1000Characters()
         {
             var validDescription = new string('T', 1000);
-            var request = _fixture.Build<ClaimRequest>()
+            var requestWithValidDescription = _fixture.Build<ClaimRequest>()
                 .With(x => x.DocumentDescription, validDescription)
+                .With(x => x.RetentionExpiresAt, _validRetentionDate)
                 .Create();
 
-            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
+            _classUnderTest.Validate(requestWithValidDescription).IsValid.Should().BeTrue();
         }
 
         [Test]
@@ -132,6 +130,20 @@ namespace DocumentsApi.Tests.V1.Validators
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
         }
+
+        [Test]
+        public void ValidatesAValidRequest()
+        {
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.RetentionExpiresAt, _validRetentionDate)
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
+        }
+
+
+
+
 
     }
 }

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -106,7 +106,7 @@ namespace DocumentsApi.Tests.V1.Validators
         {
             var tooLongDescription = new string('T', 1001);
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.DocumentDescription,tooLongDescription)
+                .With(x => x.DocumentDescription, tooLongDescription)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
@@ -117,7 +117,7 @@ namespace DocumentsApi.Tests.V1.Validators
         {
             var validDescription = new string('T', 1000);
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.DocumentDescription,validDescription)
+                .With(x => x.DocumentDescription, validDescription)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();

--- a/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.Designer.cs
+++ b/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using DocumentsApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DocumentsApi.Migrations
 {
     [DbContext(typeof(DocumentsContext))]
-    partial class DocumentsContextModelSnapshot : ModelSnapshot
+    [Migration("20220926152941_AddDescriptionToDocument")]
+    partial class AddDescriptionToDocument
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.cs
+++ b/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace DocumentsApi.Migrations
 {

--- a/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.cs
+++ b/DocumentsApi/Migrations/20220926152941_AddDescriptionToDocument.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DocumentsApi.Migrations
+{
+    public partial class AddDescriptionToDocument : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "description",
+                table: "documents",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "description",
+                table: "documents");
+        }
+    }
+}

--- a/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
@@ -11,5 +11,6 @@ namespace DocumentsApi.V1.Boundary.Request
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; }
         public string DocumentName { get; set; }
+        public string DocumentDescription { get; set; }
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/DocumentResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/DocumentResponse.cs
@@ -7,6 +7,7 @@ namespace DocumentsApi.V1.Boundary.Response
         public Guid Id { get; set; }
         public DateTime CreatedAt { get; set; }
         public string Name { get; set; }
+        public string Description { get; set; }
         public long FileSize { get; set; }
         public string FileType { get; set; }
         public DateTime? UploadedAt { get; set; }

--- a/DocumentsApi/V1/Domain/Document.cs
+++ b/DocumentsApi/V1/Domain/Document.cs
@@ -7,6 +7,7 @@ namespace DocumentsApi.V1.Domain
         public Guid Id { get; set; }
         public DateTime CreatedAt { get; set; }
         public string Name { get; set; }
+        public string Description { get; set; }
         public long FileSize { get; set; }
         public string FileType { get; set; }
         public DateTime? UploadedAt { get; set; }

--- a/DocumentsApi/V1/Domain/Document.cs
+++ b/DocumentsApi/V1/Domain/Document.cs
@@ -14,11 +14,5 @@ namespace DocumentsApi.V1.Domain
 
         public bool Uploaded => UploadedAt != null;
 
-        public Document() { }
-
-        public Document(string name)
-        {
-            this.Name = name;
-        }
     }
 }

--- a/DocumentsApi/V1/Factories/DomainFactory.cs
+++ b/DocumentsApi/V1/Factories/DomainFactory.cs
@@ -13,6 +13,7 @@ namespace DocumentsApi.V1.Factories
                 Id = entity.Id,
                 CreatedAt = entity.CreatedAt,
                 Name = entity.Name,
+                Description = entity.Description,
                 FileSize = entity.FileSize,
                 FileType = entity.FileType,
                 UploadedAt = entity.UploadedAt

--- a/DocumentsApi/V1/Factories/DomainFactory.cs
+++ b/DocumentsApi/V1/Factories/DomainFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using DocumentsApi.V1.Boundary.Request;
 using DocumentsApi.V1.Domain;
 using DocumentsApi.V1.Infrastructure;
 
@@ -32,6 +33,24 @@ namespace DocumentsApi.V1.Factories
                 RetentionExpiresAt = entity.RetentionExpiresAt,
                 ValidUntil = entity.ValidUntil,
                 TargetId = entity.TargetId
+            };
+        }
+
+        public static Claim ToDomain(this ClaimRequest request)
+        {
+            return new Claim
+            {
+                ApiCreatedBy = request.ApiCreatedBy,
+                ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
+                UserCreatedBy = request.UserCreatedBy,
+                RetentionExpiresAt = request.RetentionExpiresAt,
+                ValidUntil = request.ValidUntil,
+                TargetId = request.TargetId,
+                Document = new Document()
+                {
+                    Name = request.DocumentName,
+                    Description = request.DocumentDescription
+                }
             };
         }
 

--- a/DocumentsApi/V1/Factories/EntityFactory.cs
+++ b/DocumentsApi/V1/Factories/EntityFactory.cs
@@ -12,6 +12,7 @@ namespace DocumentsApi.V1.Factories
                 Id = domain.Id,
                 CreatedAt = domain.CreatedAt,
                 Name = domain.Name,
+                Description = domain.Description,
                 FileSize = domain.FileSize,
                 FileType = domain.FileType,
                 UploadedAt = domain.UploadedAt

--- a/DocumentsApi/V1/Factories/ResponseFactory.cs
+++ b/DocumentsApi/V1/Factories/ResponseFactory.cs
@@ -12,6 +12,7 @@ namespace DocumentsApi.V1.Factories
             {
                 CreatedAt = domain.CreatedAt,
                 Name = domain.Name,
+                Description = domain.Description,
                 FileSize = domain.FileSize,
                 FileType = domain.FileType,
                 Id = domain.Id,

--- a/DocumentsApi/V1/Infrastructure/DocumentEntity.cs
+++ b/DocumentsApi/V1/Infrastructure/DocumentEntity.cs
@@ -17,6 +17,9 @@ namespace DocumentsApi.V1.Infrastructure
         [Column("name")]
         public string Name { get; set; }
 
+        [Column("description")]
+        public string Description { get; set; }
+
         [Column("file_size")]
         public long FileSize { get; set; }
 

--- a/DocumentsApi/V1/UseCase/CreateClaimAndS3UploadPolicyUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimAndS3UploadPolicyUseCase.cs
@@ -7,15 +7,14 @@ using DocumentsApi.V1.UseCase.Interfaces;
 using DocumentsApi.V1.Validators;
 using DocumentsApi.V1.Gateways.Interfaces;
 using Microsoft.Extensions.Logging;
-using DocumentsApi.V1.Domain;
 using System.Threading.Tasks;
 
 namespace DocumentsApi.V1.UseCase
 {
     public class CreateClaimAndS3UploadPolicyUseCase : ICreateClaimAndS3UploadPolicyUseCase
     {
-        private IDocumentsGateway _documentsGateway;
-        private IS3Gateway _s3Gateway;
+        private readonly IDocumentsGateway _documentsGateway;
+        private readonly IS3Gateway _s3Gateway;
         private readonly ILogger<CreateClaimAndS3UploadPolicyUseCase> _logger;
 
         public CreateClaimAndS3UploadPolicyUseCase(
@@ -37,24 +36,11 @@ namespace DocumentsApi.V1.UseCase
                 throw new BadRequestException(validation);
             }
 
-            var claim = BuildClaim(request);
+            var claim = request.ToDomain();
             var createdClaim = _documentsGateway.CreateClaim(claim);
             var s3UploadPolicy = await _s3Gateway.GenerateUploadPolicy(createdClaim.Document).ConfigureAwait(true);
 
             return createdClaim.ToClaimAndS3UploadPolicyResponse(s3UploadPolicy);
-        }
-
-        private static Claim BuildClaim(ClaimRequest request)
-        {
-            return new Claim
-            {
-                ApiCreatedBy = request.ApiCreatedBy,
-                ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
-                UserCreatedBy = request.UserCreatedBy,
-                RetentionExpiresAt = request.RetentionExpiresAt,
-                ValidUntil = request.ValidUntil,
-                Document = new Document()
-            };
         }
     }
 }

--- a/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
@@ -41,19 +41,6 @@ namespace DocumentsApi.V1.UseCase
 
         private static Claim BuildClaimRequest(ClaimRequest request)
         {
-            if (!String.IsNullOrEmpty(request.DocumentName))
-            {
-                return new Claim
-                {
-                    ApiCreatedBy = request.ApiCreatedBy,
-                    ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
-                    UserCreatedBy = request.UserCreatedBy,
-                    RetentionExpiresAt = request.RetentionExpiresAt,
-                    ValidUntil = request.ValidUntil,
-                    TargetId = request.TargetId,
-                    Document = new Document(request.DocumentName)
-                };
-            }
             return new Claim
             {
                 ApiCreatedBy = request.ApiCreatedBy,
@@ -62,8 +49,11 @@ namespace DocumentsApi.V1.UseCase
                 RetentionExpiresAt = request.RetentionExpiresAt,
                 ValidUntil = request.ValidUntil,
                 TargetId = request.TargetId,
-                // TODO: Support creating claims for existing documents
-                Document = new Document()
+                Document = new Document
+                {
+                    Name = request.DocumentName,
+                    Description = request.DocumentDescription
+                }
             };
         }
     }

--- a/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
+++ b/DocumentsApi/V1/UseCase/CreateClaimUseCase.cs
@@ -14,7 +14,7 @@ namespace DocumentsApi.V1.UseCase
 {
     public class CreateClaimUseCase : ICreateClaimUseCase
     {
-        private IDocumentsGateway _documentsGateway;
+        private readonly IDocumentsGateway _documentsGateway;
         private readonly ILogger<CreateClaimUseCase> _logger;
 
         public CreateClaimUseCase(IDocumentsGateway documentsGateway, ILogger<CreateClaimUseCase> logger)
@@ -32,29 +32,9 @@ namespace DocumentsApi.V1.UseCase
                 throw new BadRequestException(validation);
             }
 
-            var claim = BuildClaimRequest(request);
-
+            var claim = request.ToDomain();
             var created = _documentsGateway.CreateClaim(claim);
-
             return created.ToResponse();
-        }
-
-        private static Claim BuildClaimRequest(ClaimRequest request)
-        {
-            return new Claim
-            {
-                ApiCreatedBy = request.ApiCreatedBy,
-                ServiceAreaCreatedBy = request.ServiceAreaCreatedBy,
-                UserCreatedBy = request.UserCreatedBy,
-                RetentionExpiresAt = request.RetentionExpiresAt,
-                ValidUntil = request.ValidUntil,
-                TargetId = request.TargetId,
-                Document = new Document
-                {
-                    Name = request.DocumentName,
-                    Description = request.DocumentDescription
-                }
-            };
         }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -13,7 +13,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.ApiCreatedBy).NotEmpty().NotNull();
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
-            RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1001);
+            RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1000);
         }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -13,6 +13,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.ApiCreatedBy).NotEmpty().NotNull();
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
+            RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1001);
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1185

## Describe this PR

### *What is the problem we're trying to solve*

When people make a request to create a claim in Documents API, this creates a document. We need this document entity to hold a new field: `description`, so that people can give description of up to 1000 characters.

### *What changes have we introduced*

Added a migration to the documents table to add the `Description` field.
Changes relevant Request, Response, Domain and Entity classes.
Added validation to check for up to 1000 characters
Double checked the code for the endpoints that deal with claims to make sure they're returning `Description` (and Name for the GetClaimAndS3 one) or handling a request to add `Description`.
Refactored the ClaimBuilder

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
