### PR TITLE
Add circle ci context to swaggerhub workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,6 @@ workflows:
           requires:
             - migrate-database-production
       - publish-to-swaggerhub:
-          context: api-assume-role-document-evidence-store-production-context
+          context: api-assume-role-document-evidence-store-production-context api-nuget-token-context
           requires:
             - deploy-to-production


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1141 -- part of the prod release for this ticket

## Describe this PR

### *What is the problem we're trying to solve*

the nuget context (i.e. envars) set in CircleCi UI needs to be added to the workflow yml to prevent getting the following error:
`https://app.circleci.com/pipelines/github/LBHackney-IT/documents-api/526/workflows/58377736-b7ae-4e10-a2ce-c16cf034ec62/jobs/1965?invite=true#step-106-276`

### *What changes have we introduced*

Added it to the yml

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
