### PR TITLE
Doc 1218

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ out/
 bin/
 .idea/
 tmp/
+.vs/
 .vscode/
 /documents-api.Tests/Properties/launchSettings.json
 /DocumentsApi/V1/Node/node_modules

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -466,7 +466,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"apiCreatedBy\":\"{claim2.ApiCreatedBy}\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
-                              $"\"targetId\":\"{claim2.TargetId}\"" +
+                              $"\"targetId\":\"{claim2.TargetId}\"," +
+                              $"\"targetType\":\"{claim2.TargetType}\"" +
                               "}" +
                             "]," +
                             "\"paging\":{" +
@@ -553,7 +554,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"apiCreatedBy\":\"{claim1.ApiCreatedBy}\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt1}," +
                               $"\"validUntil\":{formattedValidUntil1}," +
-                              $"\"targetId\":\"{claim1.TargetId}\"" +
+                              $"\"targetId\":\"{claim1.TargetId}\"," +
                               $"\"targetType\":\"{claim1.TargetType}\"" +
                               "}," +
                               "{" +
@@ -573,8 +574,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"apiCreatedBy\":\"{claim2.ApiCreatedBy}\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt2}," +
                               $"\"validUntil\":{formattedValidUntil2}," +
-                              $"\"targetId\":\"{claim2.TargetId}\"" +
-                              $"\"targetType\":\"{claim1.TargetType}\"" +
+                              $"\"targetId\":\"{claim2.TargetId}\"," +
+                              $"\"targetType\":\"{claim2.TargetType}\"" +
                               "}" +
                             "]," +
                             "\"paging\":{" +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -30,6 +30,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
                 $"\"validUntil\": {formattedValidUntil}," +
                 "\"targetId\": \"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
+                "\"targetType\": \"Some target type\"," +
                 "\"documentName\": \"Some name\"," +
                 "\"documentDescription\": \"Some description\"" +
                 "}";
@@ -62,6 +63,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               "\"apiCreatedBy\":\"evidence-api\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
+                              "\"targetType\": \"Some target type\"," +
                               "\"targetId\":\"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"" +
                               "}";
 
@@ -111,7 +113,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               "\"apiCreatedBy\":\"evidence-api\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
-                              "\"targetId\":null" +
+                              "\"targetId\":null," +
+                              "\"targetType\":null" +
                               "}";
 
             json.Should().Be(expected);
@@ -380,7 +383,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"apiCreatedBy\":\"{claim.ApiCreatedBy}\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
-                              $"\"targetId\":\"{claim.TargetId}\"" +
+                              $"\"targetId\":\"{claim.TargetId}\"," +
+                              $"\"targetType\":\"{claim.TargetType}\"" +
                               "}" +
                             "]," +
                             "\"paging\":{" +

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -29,8 +29,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "\"apiCreatedBy\": \"evidence-api\"," +
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
                 $"\"validUntil\": {formattedValidUntil}," +
-                "\"targetId\": \"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
                 "\"targetType\": \"Some target type\"," +
+                "\"targetId\": \"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
                 "\"documentName\": \"Some name\"," +
                 "\"documentDescription\": \"Some description\"" +
                 "}";
@@ -63,8 +63,8 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               "\"apiCreatedBy\":\"evidence-api\"," +
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
-                              "\"targetType\": \"Some target type\"," +
-                              "\"targetId\":\"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"" +
+                              "\"targetId\":\"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
+                              "\"targetType\":\"Some target type\"" +
                               "}";
 
             json.Should().Be(expected);

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -29,7 +29,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                 "\"apiCreatedBy\": \"evidence-api\"," +
                 $"\"retentionExpiresAt\": {formattedRetentionExpiresAt}," +
                 $"\"validUntil\": {formattedValidUntil}," +
-                "\"targetType\": \"Some target type\"," +
+                "\"targetType\": \"person\"," +
                 "\"targetId\": \"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
                 "\"documentName\": \"Some name\"," +
                 "\"documentDescription\": \"Some description\"" +
@@ -64,7 +64,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
                               $"\"validUntil\":{formattedValidUntil}," +
                               "\"targetId\":\"eaed0ee5-d88c-4cf1-9df9-268a24ea0450\"," +
-                              "\"targetType\":\"Some target type\"" +
+                              "\"targetType\":\"person\"" +
                               "}";
 
             json.Should().Be(expected);

--- a/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/ClaimsTest.cs
@@ -554,6 +554,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt1}," +
                               $"\"validUntil\":{formattedValidUntil1}," +
                               $"\"targetId\":\"{claim1.TargetId}\"" +
+                              $"\"targetType\":\"{claim1.TargetType}\"" +
                               "}," +
                               "{" +
                               $"\"id\":\"{claim2.Id}\"," +
@@ -573,6 +574,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt2}," +
                               $"\"validUntil\":{formattedValidUntil2}," +
                               $"\"targetId\":\"{claim2.TargetId}\"" +
+                              $"\"targetType\":\"{claim1.TargetType}\"" +
                               "}" +
                             "]," +
                             "\"paging\":{" +

--- a/DocumentsApi.Tests/V1/Factories/DomainFactoryTests.cs
+++ b/DocumentsApi.Tests/V1/Factories/DomainFactoryTests.cs
@@ -51,6 +51,7 @@ namespace DocumentsApi.Tests.V1.Factories
             domain.ServiceAreaCreatedBy.Should().Be(entity.ServiceAreaCreatedBy);
             domain.RetentionExpiresAt.Should().Be(entity.RetentionExpiresAt);
             domain.TargetId.Should().Be(entity.TargetId);
+            domain.TargetType.Should().Be(entity.TargetType);
         }
 
         [Test]

--- a/DocumentsApi.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/DocumentsApi.Tests/V1/Factories/EntityFactoryTests.cs
@@ -42,6 +42,7 @@ namespace DocumentsApi.Tests.V1.Factories
             domain.ServiceAreaCreatedBy.Should().Be(entity.ServiceAreaCreatedBy);
             domain.RetentionExpiresAt.Should().Be(entity.RetentionExpiresAt);
             domain.TargetId.Should().Be(entity.TargetId);
+            domain.TargetType.Should().Be(entity.TargetType);
         }
     }
 }

--- a/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/DocumentsApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -46,6 +46,7 @@ namespace DocumentsApi.Tests.V1.Factories
                 RetentionExpiresAt = response.RetentionExpiresAt,
                 ValidUntil = response.ValidUntil,
                 TargetId = response.TargetId,
+                TargetType = response.TargetType,
                 S3UploadPolicy = response.S3UploadPolicy
             };
 
@@ -73,6 +74,7 @@ namespace DocumentsApi.Tests.V1.Factories
                 RetentionExpiresAt = response.RetentionExpiresAt,
                 ValidUntil = response.ValidUntil,
                 TargetId = response.TargetId,
+                TargetType = response.TargetType,
                 PreSignedDownloadUrl = s3PreSignedDownloadUrl
             };
 

--- a/DocumentsApi.Tests/V1/UseCase/CreateClaimUseCaseTests.cs
+++ b/DocumentsApi.Tests/V1/UseCase/CreateClaimUseCaseTests.cs
@@ -35,6 +35,7 @@ namespace DocumentsApi.Tests.V1.UseCase
         {
             var request = _fixture.Build<ClaimRequest>()
                 .With(x => x.RetentionExpiresAt, DateTime.UtcNow.AddDays(1))
+                .With(x => x.TargetType, "person")
                 .Create();
 
             Func<ClaimResponse> execute = () => _classUnderTest.Execute(request);
@@ -48,6 +49,7 @@ namespace DocumentsApi.Tests.V1.UseCase
         public void ReturnsAClaimResponse()
         {
             var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.TargetType, "person")
                 .With(x => x.RetentionExpiresAt, DateTime.UtcNow.AddDays(1))
                 .Create();
 

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -131,6 +131,27 @@ namespace DocumentsApi.Tests.V1.Validators
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
         }
 
+
+        [Test]
+        public void AcceptsWhenTargetTypeIsEmpty()
+        {
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.TargetType, "")
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
+        }
+        [Test]
+        public void FailsWhenTargetTypeIsOver50Character()
+        {
+            var targetTypeOver50Characters = new string('T', 51);
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.TargetType, targetTypeOver50Characters)
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeFalse();
+        }
+
         [Test]
         public void ValidatesAValidRequest()
         {

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -133,7 +133,6 @@ namespace DocumentsApi.Tests.V1.Validators
 
 
         [Test]
-        [TestCase(null)]
         public void AcceptsWhenTargetTypeIsNull(string value)
         {
             var request = _fixture.Build<ClaimRequest>()
@@ -141,6 +140,16 @@ namespace DocumentsApi.Tests.V1.Validators
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();
+        }
+        [Test]
+        public void FailsWhenTargetTypeIsLessThanOneCharacter()
+        {
+            var targetTypeLessThanOneCharacter = "";
+            var request = _fixture.Build<ClaimRequest>()
+                .With(x => x.TargetType, targetTypeLessThanOneCharacter)
+                .Create();
+
+            _classUnderTest.Validate(request).IsValid.Should().BeFalse();
         }
         [Test]
         public void FailsWhenTargetTypeIsOver50Character()

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -116,6 +116,7 @@ namespace DocumentsApi.Tests.V1.Validators
             var requestWithValidDescription = _fixture.Build<ClaimRequest>()
                 .With(x => x.DocumentDescription, validDescription)
                 .With(x => x.RetentionExpiresAt, _validRetentionDate)
+                .With(x => x.TargetType, "person")
                 .Create();
 
             _classUnderTest.Validate(requestWithValidDescription).IsValid.Should().BeTrue();

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -133,10 +133,11 @@ namespace DocumentsApi.Tests.V1.Validators
 
 
         [Test]
-        public void AcceptsWhenTargetTypeIsNull()
+        [TestCase(null)]
+        public void AcceptsWhenTargetTypeIsNull(string value)
         {
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType)
+                .With(x => x.TargetType,value)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -137,7 +137,7 @@ namespace DocumentsApi.Tests.V1.Validators
         public void AcceptsWhenTargetTypeIsNull(string value)
         {
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType,value)
+                .With(x => x.TargetType, value)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -131,22 +131,11 @@ namespace DocumentsApi.Tests.V1.Validators
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
         }
 
-
-        [Test]
-        public void AcceptsWhenTargetTypeIsNull(string value)
-        {
-            var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType, value)
-                .Create();
-
-            _classUnderTest.Validate(request).IsValid.Should().BeTrue();
-        }
         [Test]
         public void FailsWhenTargetTypeIsLessThanOneCharacter()
         {
-            var targetTypeLessThanOneCharacter = "";
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType, targetTypeLessThanOneCharacter)
+                .With(x => x.TargetType, "")
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -132,20 +132,10 @@ namespace DocumentsApi.Tests.V1.Validators
         }
 
         [Test]
-        public void FailsWhenTargetTypeIsLessThanOneCharacter()
+        public void FailsWhenTargetTypeIsNotValid()
         {
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType, "")
-                .Create();
-
-            _classUnderTest.Validate(request).IsValid.Should().BeFalse();
-        }
-        [Test]
-        public void FailsWhenTargetTypeIsOver50Character()
-        {
-            var targetTypeOver50Characters = new string('T', 51);
-            var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType, targetTypeOver50Characters)
+                .With(x => x.TargetType, "test")
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeFalse();
@@ -156,6 +146,7 @@ namespace DocumentsApi.Tests.V1.Validators
         {
             var request = _fixture.Build<ClaimRequest>()
                 .With(x => x.RetentionExpiresAt, _validRetentionDate)
+                .With(x => x.TargetType, "person")
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();

--- a/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
+++ b/DocumentsApi.Tests/V1/Validators/ClaimRequestValidatorTests.cs
@@ -133,10 +133,10 @@ namespace DocumentsApi.Tests.V1.Validators
 
 
         [Test]
-        public void AcceptsWhenTargetTypeIsEmpty()
+        public void AcceptsWhenTargetTypeIsNull()
         {
             var request = _fixture.Build<ClaimRequest>()
-                .With(x => x.TargetType, "")
+                .With(x => x.TargetType)
                 .Create();
 
             _classUnderTest.Validate(request).IsValid.Should().BeTrue();

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -20,7 +20,8 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.7.10" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
+    <PackageReference Include="Hackney.Core.Enums" Version="1.74.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.7.10" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
-    <PackageReference Include="Hackney.Core.Enums" Version="1.74.0" />
+    <PackageReference Include="Hackney.Core.Enums" Version="1.75.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />

--- a/DocumentsApi/Migrations/20221006145141_AddTargetTypeToClaim.Designer.cs
+++ b/DocumentsApi/Migrations/20221006145141_AddTargetTypeToClaim.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using DocumentsApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DocumentsApi.Migrations
 {
     [DbContext(typeof(DocumentsContext))]
-    partial class DocumentsContextModelSnapshot : ModelSnapshot
+    [Migration("20221006145141_AddTargetTypeToClaim")]
+    partial class AddTargetTypeToClaim
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DocumentsApi/Migrations/20221006145141_AddTargetTypeToClaim.cs
+++ b/DocumentsApi/Migrations/20221006145141_AddTargetTypeToClaim.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DocumentsApi.Migrations
+{
+    public partial class AddTargetTypeToClaim : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "target_type",
+                table: "claims",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "target_type",
+                table: "claims");
+        }
+    }
+}

--- a/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/DocumentsApi/V1/Boundary/Request/ClaimRequest.cs
@@ -12,5 +12,6 @@ namespace DocumentsApi.V1.Boundary.Request
         public Guid? TargetId { get; set; }
         public string DocumentName { get; set; }
         public string DocumentDescription { get; set; }
+        public string TargetType { get; set; }
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimAndPreSignedDownloadUrlResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimAndPreSignedDownloadUrlResponse.cs
@@ -17,5 +17,6 @@ namespace DocumentsApi.V1.Boundary.Response
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; } = null;
         public string PreSignedDownloadUrl { get; set; }
+        public string TargetType { get; set; }
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimAndS3UploadPolicyResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimAndS3UploadPolicyResponse.cs
@@ -16,6 +16,5 @@ namespace DocumentsApi.V1.Boundary.Response
         public Guid? TargetId { get; set; } = null;
         public S3UploadPolicy S3UploadPolicy { get; set; }
         public string TargetType { get; set; }
-
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimAndS3UploadPolicyResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimAndS3UploadPolicyResponse.cs
@@ -15,5 +15,7 @@ namespace DocumentsApi.V1.Boundary.Response
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; } = null;
         public S3UploadPolicy S3UploadPolicy { get; set; }
+        public string TargetType { get; set; }
+
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimResponse.cs
@@ -14,7 +14,6 @@ namespace DocumentsApi.V1.Boundary.Response
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; } = null;
-
         public string TargetType { get; set; }
     }
 }

--- a/DocumentsApi/V1/Boundary/Response/ClaimResponse.cs
+++ b/DocumentsApi/V1/Boundary/Response/ClaimResponse.cs
@@ -14,5 +14,7 @@ namespace DocumentsApi.V1.Boundary.Response
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; } = null;
+
+        public string TargetType { get; set; }
     }
 }

--- a/DocumentsApi/V1/Domain/Claim.cs
+++ b/DocumentsApi/V1/Domain/Claim.cs
@@ -13,6 +13,7 @@ namespace DocumentsApi.V1.Domain
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
         public Guid? TargetId { get; set; } = null;
+        public string TargetType { get; set; }
 
         public virtual bool Expired => RetentionExpiresAt.CompareTo(DateTime.UtcNow) < 0;
     }

--- a/DocumentsApi/V1/Factories/DomainFactory.cs
+++ b/DocumentsApi/V1/Factories/DomainFactory.cs
@@ -32,7 +32,8 @@ namespace DocumentsApi.V1.Factories
                 ServiceAreaCreatedBy = entity.ServiceAreaCreatedBy,
                 RetentionExpiresAt = entity.RetentionExpiresAt,
                 ValidUntil = entity.ValidUntil,
-                TargetId = entity.TargetId
+                TargetId = entity.TargetId,
+                TargetType = entity.TargetType
             };
         }
 
@@ -46,6 +47,7 @@ namespace DocumentsApi.V1.Factories
                 RetentionExpiresAt = request.RetentionExpiresAt,
                 ValidUntil = request.ValidUntil,
                 TargetId = request.TargetId,
+                TargetType = request.TargetType,
                 Document = new Document()
                 {
                     Name = request.DocumentName,

--- a/DocumentsApi/V1/Factories/EntityFactory.cs
+++ b/DocumentsApi/V1/Factories/EntityFactory.cs
@@ -32,7 +32,8 @@ namespace DocumentsApi.V1.Factories
                 ServiceAreaCreatedBy = domain.ServiceAreaCreatedBy,
                 RetentionExpiresAt = domain.RetentionExpiresAt,
                 ValidUntil = domain.ValidUntil,
-                TargetId = domain.TargetId
+                TargetId = domain.TargetId,
+                TargetType = domain.TargetType
             };
         }
     }

--- a/DocumentsApi/V1/Factories/ResponseFactory.cs
+++ b/DocumentsApi/V1/Factories/ResponseFactory.cs
@@ -33,7 +33,8 @@ namespace DocumentsApi.V1.Factories
                 RetentionExpiresAt = domain.RetentionExpiresAt,
                 UserCreatedBy = domain.UserCreatedBy,
                 ValidUntil = domain.ValidUntil,
-                TargetId = domain.TargetId
+                TargetId = domain.TargetId,
+                TargetType = domain.TargetType
             };
         }
 
@@ -52,6 +53,7 @@ namespace DocumentsApi.V1.Factories
                 UserCreatedBy = claim.UserCreatedBy,
                 ValidUntil = claim.ValidUntil,
                 TargetId = claim.TargetId,
+                TargetType = claim.TargetType,
                 PreSignedDownloadUrl = preSignedDownloadUrl
             };
         }
@@ -69,6 +71,7 @@ namespace DocumentsApi.V1.Factories
                 UserCreatedBy = claim.UserCreatedBy,
                 ValidUntil = claim.ValidUntil,
                 TargetId = claim.TargetId,
+                TargetType = claim.TargetType,
                 S3UploadPolicy = s3UploadPolicy
             };
         }

--- a/DocumentsApi/V1/Infrastructure/ClaimEntity.cs
+++ b/DocumentsApi/V1/Infrastructure/ClaimEntity.cs
@@ -44,5 +44,8 @@ namespace DocumentsApi.V1.Infrastructure
 
         [Column("target_id")]
         public Guid? TargetId { get; set; } = null;
+
+        [Column("target_type")]
+        public string TargetType { get; set; }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -14,6 +14,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
             RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1000);
+            RuleFor(x => x.TargetType).MinimumLength(0).MaximumLength(50);
         }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -14,7 +14,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
             RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1000);
-            RuleFor(x => x.TargetType).MinimumLength(0).MaximumLength(50);
+            RuleFor(x => x.TargetType).MaximumLength(50);
         }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -14,7 +14,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
             RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1000);
-            RuleFor(x => x.TargetType).MaximumLength(50);
+            RuleFor(x => x.TargetType).MinimumLength(1).MaximumLength(50);
         }
     }
 }

--- a/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
+++ b/DocumentsApi/V1/Validators/ClaimRequestValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using DocumentsApi.V1.Boundary.Request;
 using FluentValidation;
+using Hackney.Core.Enums;
 
 namespace DocumentsApi.V1.Validators
 {
@@ -14,7 +15,7 @@ namespace DocumentsApi.V1.Validators
             RuleFor(x => x.RetentionExpiresAt).NotNull().GreaterThan(DateTime.UtcNow);
             RuleFor(x => x.DocumentName).MinimumLength(1).MaximumLength(300);
             RuleFor(x => x.DocumentDescription).MinimumLength(1).MaximumLength(1000);
-            RuleFor(x => x.TargetType).MinimumLength(1).MaximumLength(50);
+            RuleFor(x => x.TargetType).IsTargetType();
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1218

## Describe this PR

### *What is the problem we're trying to solve*

 Adding targetType to the claim would provide information on what type of entity the targetId is and better assist callers of the API with context about the claim that they may be missing.

### *What changes have we introduced*

- Added migration to the claims table to add the `targetType` field.
- Updated Request, Response, Domain and Entity classes for claim to include 'targetType'
- Updated relevant test cases
- Added validation using Nuget package for TargetType enums

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.

Test the changes in staging
