### PR TITLE
DOC-1076 - Upgrade to Dotnet 6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: circleci/python:3.7
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/DocumentsApi.Tests/Dockerfile
+++ b/DocumentsApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/DocumentsApi.Tests/DocumentsApi.Tests.csproj
+++ b/DocumentsApi.Tests/DocumentsApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+     <TargetFramework>net6.0</TargetFramework>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
@@ -15,16 +15,19 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="dotenv.net" Version="2.1.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageReference Include="dotenv.net" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocumentsApi.Tests/DocumentsApi.Tests.csproj
+++ b/DocumentsApi.Tests/DocumentsApi.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />

--- a/DocumentsApi.Tests/GlobalSetup.cs
+++ b/DocumentsApi.Tests/GlobalSetup.cs
@@ -13,7 +13,7 @@ public class GlobalSetup
     {
         try
         {
-            DotEnv.Config(true, Path.GetFullPath("../../../../.env"));
+            DotEnv.Load();
         }
         catch
         {

--- a/DocumentsApi.Tests/GlobalSetup.cs
+++ b/DocumentsApi.Tests/GlobalSetup.cs
@@ -14,6 +14,7 @@ public class GlobalSetup
         try
         {
             DotEnv.Load();
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
         }
         catch
         {

--- a/DocumentsApi.Tests/V1/E2ETests/HealthCheckTests.cs
+++ b/DocumentsApi.Tests/V1/E2ETests/HealthCheckTests.cs
@@ -18,7 +18,7 @@ namespace DocumentsApi.Tests.V1.E2ETests
             var expected = new ProblemDetails
             {
                 Status = StatusCodes.Status500InternalServerError,
-                Title = "An error occured while processing your request.",
+                Title = "An error occurred while processing your request.",
                 Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
             };
 

--- a/DocumentsApi/Dockerfile
+++ b/DocumentsApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
+      <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -29,7 +29,10 @@
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
@@ -37,8 +40,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="dotenv.net" Version="2.1.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageReference Include="dotenv.net" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocumentsApi/DocumentsApi.csproj
+++ b/DocumentsApi/DocumentsApi.csproj
@@ -33,9 +33,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.6.3" />

--- a/DocumentsApi/Startup.cs
+++ b/DocumentsApi/Startup.cs
@@ -43,7 +43,6 @@ namespace DocumentsApi
                 {
                     c.Filters.Add<HandleExceptionAttribute>();
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddFluentValidation();
 
             var apiVersions = new List<ApiVersion>();
@@ -122,11 +121,8 @@ namespace DocumentsApi
                     c.IncludeXmlComments(xmlPath);
             });
 
-            var success = DotEnv.AutoConfig(5);
-            if (success)
-            {
-                Console.WriteLine("LOADED ENVIRONMENT FROM .env");
-            }
+            DotEnv.Load();
+            Console.WriteLine("LOADED ENVIRONMENT FROM .env");
 
             services.AddTokenFactory()
                 .AddHttpContextWrapper();

--- a/DocumentsApi/build.sh
+++ b/DocumentsApi/build.sh
@@ -18,6 +18,6 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/documents-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/documents-api.zip
 
 cd python && zip -rv ../lambda-orchestrator.zip ./*

--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -1,7 +1,7 @@
 service: documents-api
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
@@ -39,7 +39,7 @@ provider:
             AllowedOrigins: ${self:custom.corsDomains.${self:provider.stage}}
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/documents-api.zip
+  artifact: ./bin/release/net6.0/documents-api.zip
   individually: true
 
 functions:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Documents API is a Platform API to securely and easily store and retrieve docume
 
 ## Stack
 
--   .NET Core v3.1 as a web framework.
--   nUnit v3.11 as a test framework.
+-   .NET 6.0 as a web framework.
+-   nUnit v3.12 as a test framework.
 
 ## What does it do?
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Install dotnet-ef globally
 ENV PATH $PATH:/root/.dotnet/tools
-RUN dotnet tool install --global dotnet-ef --version 6.0.5
+RUN dotnet tool install --global dotnet-ef --version 7.0.0
 
 RUN apt-get update
 RUN apt-get install sudo


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1076

## Describe this PR

This PR upgrades the Documents API to run on Dotnet 6, replacing Dotnet 3.1 which is coming to end of life. Packages have been upgraded, and refactoring has been done where methods are no longer supported.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test in staging, once the Evidence API upgrade has also been completed.
