### PR TITLE
Switch to the Cognito authorizer on `staging` environment.

### DIFF
--- a/DocumentsApi/serverless.yml
+++ b/DocumentsApi/serverless.yml
@@ -165,7 +165,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   corsDomains:
     staging:


### PR DESCRIPTION
# What:
 - Switch to the Cognito authorizer on `staging` environment.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `staging`.
 
# Notes:
 - This repository has never had a working `development` environment - it was removed by this [commit](https://github.com/LBHackney-IT/documents-api/commit/86df21fdf363b71773303b7246b0bcec84051971) shortly after the repository was created. As such, the `development` authorizer configuration was left as is.