### PR TITLE
Change active maintainers to shared services team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services
+* @LBHackney-IT/shared-services

--- a/README.md
+++ b/README.md
@@ -184,13 +184,7 @@ Documentation on how to do this can be found [here](https://docs.microsoft.com/e
 
 ### Active Maintainers
 
--   **Selwyn Preston**, Lead Developer at London Borough of Hackney (selwyn.preston@hackney.gov.uk)
--   **Mirela Georgieva**, Lead Developer at London Borough of Hackney (mirela.georgieva@hackney.gov.uk)
--   **Matt Keyworth**, Lead Developer at London Borough of Hackney (matthew.keyworth@hackney.gov.uk)
-
-### Other Contacts
-
--   **Rashmi Shetty**, Product Owner at London Borough of Hackney (rashmi.shetty@hackney.gov.uk)
+-   **Shared Services team**, Maintenance team (shared.services@hackney.gov.uk)
 
 [docker-download]: https://www.docker.com/products/docker-desktop
 [made-tech]: https://madetech.com/


### PR DESCRIPTION
### What & Why
Update the readme and code owners to specify the shared services team as the active maintainers. This is to provide a fresh pipeline for the auth switchover which will happen soon after.